### PR TITLE
Add acreage rate selection to quote and update project on approve

### DIFF
--- a/Harvest.Core/Domain/Project.cs
+++ b/Harvest.Core/Domain/Project.cs
@@ -24,6 +24,11 @@ namespace Harvest.Core.Domain
         
         [MaxLength]
         public string Requirements { get; set; }
+
+        public double Acres { get; set; }
+
+        public int? AcreageRateId { get; set; }
+        public Rate AcreageRate { get; set; }
         
         [StringLength(200)]
         public string Name { get; set; }

--- a/Harvest.Core/Domain/Rate.cs
+++ b/Harvest.Core/Domain/Rate.cs
@@ -55,6 +55,9 @@ namespace Harvest.Core.Domain
         [Display(Name = "Updated Date")]
         public DateTime UpdatedOn { get; set; }
 
+        // projects using this rate
+        public List<Project> Projects { get; set; }
+
         internal static void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Rate>().HasIndex(a => a.Type);
@@ -64,6 +67,13 @@ namespace Harvest.Core.Domain
 
 
             modelBuilder.Entity<Rate>().Property(a => a.Price).HasPrecision(18, 2);
+
+            modelBuilder.Entity<Project>()
+                .HasOne(a => a.AcreageRate)
+                .WithMany(p => p.Projects)
+                .HasForeignKey(a => a.AcreageRateId)
+                .OnDelete(DeleteBehavior.Restrict);
+
         }
 
         public class Types

--- a/Harvest.Core/Migrations/SqlServer/20210421164620_ProjectAcres.Designer.cs
+++ b/Harvest.Core/Migrations/SqlServer/20210421164620_ProjectAcres.Designer.cs
@@ -3,46 +3,52 @@ using System;
 using Harvest.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
-namespace Harvest.Core.Migrations.Sqlite
+namespace Harvest.Core.Migrations.SqlServer
 {
-    [DbContext(typeof(AppDbContextSqlite))]
-    partial class AppDbContextSqliteModelSnapshot : ModelSnapshot
+    [DbContext(typeof(AppDbContextSqlServer))]
+    [Migration("20210421164620_ProjectAcres")]
+    partial class ProjectAcres
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
+                .UseIdentityColumns()
+                .HasAnnotation("Relational:MaxIdentifierLength", 128)
                 .HasAnnotation("ProductVersion", "5.0.1");
 
             modelBuilder.Entity("Harvest.Core.Domain.Account", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<int?>("ApprovedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("ApprovedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("Number")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<decimal>("Percentage")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -61,19 +67,20 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<string>("Identifier")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("QuoteId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -89,47 +96,48 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<string>("Account")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int?>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<int?>("InvoiceId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("Price")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("Quantity")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("RateId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(15)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(15)");
 
                     b.HasKey("Id");
 
@@ -148,31 +156,32 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("KfsTrackingNumber")
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("SlothTransactionId")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Status")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.HasKey("Id");
 
@@ -185,27 +194,28 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<string>("Body")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("Sent")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Subject")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.HasKey("Id");
 
@@ -218,13 +228,14 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<int>("RoleId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("UserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -239,70 +250,71 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<int?>("AcreageRateId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<double>("Acres")
-                        .HasColumnType("REAL");
+                        .HasColumnType("float");
 
                     b.Property<decimal>("ChargedTotal")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Crop")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("CurrentAccountVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("End")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<Geometry>("Location")
-                        .HasColumnType("GEOMETRY");
+                        .HasColumnType("geography");
 
                     b.Property<string>("LocationCode")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<int>("PrincipalInvestigatorId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int?>("QuoteId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int?>("QuoteId1")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("QuoteTotal")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Requirements")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("Start")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -325,32 +337,33 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<string>("Action")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<DateTime>("ActionDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("Actor")
                         .HasMaxLength(20)
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("ActorName")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Type")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -363,43 +376,45 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<int?>("ApprovedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("ApprovedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("CurrentDocumentId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("InitiatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Text")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("ApprovedById");
 
                     b.HasIndex("CurrentDocumentId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[CurrentDocumentId] IS NOT NULL");
 
                     b.HasIndex("InitiatedById");
 
@@ -412,52 +427,53 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<string>("Account")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("BillingUnit")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<DateTime?>("EffectiveOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<decimal>("Price")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(15)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(15)");
 
                     b.Property<string>("Unit")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("UpdatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("UpdatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 
@@ -476,12 +492,13 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -495,24 +512,25 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<string>("Account")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("InvoiceId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(10)");
 
                     b.HasKey("Id");
 
@@ -525,30 +543,31 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .UseIdentityColumn();
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.Property<string>("FirstName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Iam")
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(10)");
 
                     b.Property<string>("Kerberos")
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.Property<string>("LastName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 

--- a/Harvest.Core/Migrations/SqlServer/20210421164620_ProjectAcres.cs
+++ b/Harvest.Core/Migrations/SqlServer/20210421164620_ProjectAcres.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Harvest.Core.Migrations.SqlServer
+{
+    public partial class ProjectAcres : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AcreageRateId",
+                table: "Projects",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "Acres",
+                table: "Projects",
+                type: "float",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_AcreageRateId",
+                table: "Projects",
+                column: "AcreageRateId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Projects_Rates_AcreageRateId",
+                table: "Projects",
+                column: "AcreageRateId",
+                principalTable: "Rates",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Projects_Rates_AcreageRateId",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_AcreageRateId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "AcreageRateId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "Acres",
+                table: "Projects");
+        }
+    }
+}

--- a/Harvest.Core/Migrations/SqlServer/AppDbContextSqlServerModelSnapshot.cs
+++ b/Harvest.Core/Migrations/SqlServer/AppDbContextSqlServerModelSnapshot.cs
@@ -251,6 +251,12 @@ namespace Harvest.Core.Migrations.SqlServer
                         .HasColumnType("int")
                         .UseIdentityColumn();
 
+                    b.Property<int?>("AcreageRateId")
+                        .HasColumnType("int");
+
+                    b.Property<double>("Acres")
+                        .HasColumnType("float");
+
                     b.Property<decimal>("ChargedTotal")
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
@@ -309,6 +315,8 @@ namespace Harvest.Core.Migrations.SqlServer
                         .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("AcreageRateId");
 
                     b.HasIndex("CreatedById");
 
@@ -671,6 +679,11 @@ namespace Harvest.Core.Migrations.SqlServer
 
             modelBuilder.Entity("Harvest.Core.Domain.Project", b =>
                 {
+                    b.HasOne("Harvest.Core.Domain.Rate", "AcreageRate")
+                        .WithMany("Projects")
+                        .HasForeignKey("AcreageRateId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
                     b.HasOne("Harvest.Core.Domain.User", "CreatedBy")
                         .WithMany("CreatedProjects")
                         .HasForeignKey("CreatedById")
@@ -686,6 +699,8 @@ namespace Harvest.Core.Migrations.SqlServer
                     b.HasOne("Harvest.Core.Domain.Quote", "Quote")
                         .WithMany()
                         .HasForeignKey("QuoteId1");
+
+                    b.Navigation("AcreageRate");
 
                     b.Navigation("CreatedBy");
 
@@ -789,6 +804,11 @@ namespace Harvest.Core.Migrations.SqlServer
             modelBuilder.Entity("Harvest.Core.Domain.Quote", b =>
                 {
                     b.Navigation("Documents");
+                });
+
+            modelBuilder.Entity("Harvest.Core.Domain.Rate", b =>
+                {
+                    b.Navigation("Projects");
                 });
 
             modelBuilder.Entity("Harvest.Core.Domain.User", b =>

--- a/Harvest.Core/Migrations/Sqlite/20210421164613_ProjectAcres.Designer.cs
+++ b/Harvest.Core/Migrations/Sqlite/20210421164613_ProjectAcres.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Harvest.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
 namespace Harvest.Core.Migrations.Sqlite
 {
     [DbContext(typeof(AppDbContextSqlite))]
-    partial class AppDbContextSqliteModelSnapshot : ModelSnapshot
+    [Migration("20210421164613_ProjectAcres")]
+    partial class ProjectAcres
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Harvest.Core/Migrations/Sqlite/20210421164613_ProjectAcres.cs
+++ b/Harvest.Core/Migrations/Sqlite/20210421164613_ProjectAcres.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Harvest.Core.Migrations.Sqlite
+{
+    public partial class ProjectAcres : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AcreageRateId",
+                table: "Projects",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "Acres",
+                table: "Projects",
+                type: "REAL",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_AcreageRateId",
+                table: "Projects",
+                column: "AcreageRateId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Projects_Rates_AcreageRateId",
+                table: "Projects",
+                column: "AcreageRateId",
+                principalTable: "Rates",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Projects_Rates_AcreageRateId",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_AcreageRateId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "AcreageRateId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "Acres",
+                table: "Projects");
+        }
+    }
+}

--- a/Harvest.Web/ClientApp/src/Quotes/ProjectDetail.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ProjectDetail.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { QuoteContent, WorkItemImpl } from "../types";
+import { QuoteContent, Rate, WorkItemImpl } from "../types";
 
 import {
   Button,
@@ -15,6 +15,7 @@ import {
 import { formatCurrency } from "../Util/NumberFormatting";
 
 interface Props {
+  rates: Rate[];
   quote: QuoteContent;
   updateQuote: React.Dispatch<React.SetStateAction<QuoteContent>>;
 }
@@ -41,6 +42,24 @@ export const ProjectDetail = (props: Props) => {
       ],
     });
   };
+
+  const setAcreageRate = (rate: Rate | undefined) => {
+    if (rate) {
+      props.updateQuote({
+        ...props.quote,
+        acreageRate: rate.price,
+        acreageRateId: rate.id,
+        acreageRateDescription: rate.description,
+      });
+    } else {
+      props.updateQuote({
+        ...props.quote,
+        acreageRate: 0,
+        acreageRateId: 0,
+        acreageRateDescription: "",
+      });
+    }
+  };
   return (
     <Row className="align-items-baseline">
       {/* Left Details */}
@@ -56,56 +75,84 @@ export const ProjectDetail = (props: Props) => {
         />
         <br />
         <Row className="align-items-baseline">
-          <Col md="4">
-            <Label for="acres">Number of Acres</Label>
+          <Col>
+            <Label>Acreage Rate</Label>
             <Input
-              type="number"
-              id="acres"
-              value={props.quote.acres}
+              type="select"
+              name="acreageRate"
+              value={props.quote.acreageRateId}
               onChange={(e) =>
-                props.updateQuote({
-                  ...props.quote,
-                  acres: parseInt(e.target.value ?? 0),
-                })
+                setAcreageRate(
+                  props.rates.find((r) => r.id === parseInt(e.target.value))
+                )
               }
-            />
+            >
+              <option value="0">-- Select Acreage Rate --</option>
+              {props.rates
+                .filter((r) => r.type === "Acreage")
+                .map((r) => (
+                  <option key={`rate-${r.type}-${r.id}`} value={r.id}>
+                    {r.description}
+                  </option>
+                ))}
+            </Input>
           </Col>
-          <Col md="4">
-            <Label for="rate">Rate</Label>
-            <InputGroup>
-              <InputGroupAddon addonType="prepend">
-                <InputGroupText>$</InputGroupText>
-              </InputGroupAddon>
+        </Row>
+        <br />
+        {props.quote.acreageRateId > 0 && (
+          <Row className="align-items-baseline">
+            <Col md="4">
+              <Label for="acres">Number of Acres</Label>
               <Input
                 type="number"
-                id="rate"
-                value={props.quote.acreageRate}
+                id="acres"
+                value={props.quote.acres}
                 onChange={(e) =>
                   props.updateQuote({
                     ...props.quote,
-                    acreageRate: parseInt(e.target.value ?? 0),
+                    acres: parseInt(e.target.value ?? 0),
                   })
                 }
               />
-            </InputGroup>
-          </Col>
-          <Col md="4">
-            <Label>Total Acreage Fee</Label>
-            <InputGroup>
-              <InputGroupAddon addonType="prepend">
-                <InputGroupText>$</InputGroupText>
-              </InputGroupAddon>
-              <Input
-                type="text"
-                id="rate"
-                readOnly
-                value={formatCurrency(
-                  props.quote.acres * props.quote.acreageRate
-                )}
-              />
-            </InputGroup>
-          </Col>
-        </Row>
+            </Col>
+            <Col md="4">
+              <Label for="rate">Rate</Label>
+              <InputGroup>
+                <InputGroupAddon addonType="prepend">
+                  <InputGroupText>$</InputGroupText>
+                </InputGroupAddon>
+                <Input
+                  type="number"
+                  id="rate"
+                  value={props.quote.acreageRate}
+                  onChange={(e) =>
+                    props.updateQuote({
+                      ...props.quote,
+                      acreageRate: parseInt(e.target.value ?? 0),
+                    })
+                  }
+                />
+              </InputGroup>
+            </Col>
+            <Col md="4">
+              <Label>Total Acreage Fee</Label>
+              <InputGroup>
+                <InputGroupAddon addonType="prepend">
+                  <InputGroupText>$</InputGroupText>
+                </InputGroupAddon>
+                <Input
+                  type="text"
+                  id="rate"
+                  readOnly
+                  value={formatCurrency(
+                    props.quote.acres * props.quote.acreageRate
+                  )}
+                />
+              </InputGroup>
+            </Col>
+          </Row>
+        )}
+
         <br />
         <Button
           className="mb-4"

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -130,7 +130,7 @@ export const QuoteContainer = () => {
           <div className="quote-details">
             <h2>Quote Details</h2>
             <hr />
-            <ProjectDetail quote={quote} updateQuote={setQuote} />
+            <ProjectDetail rates={rates} quote={quote} updateQuote={setQuote} />
             <ActivitiesContainer
               quote={quote}
               rates={rates}

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteDisplay.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteDisplay.tsx
@@ -13,6 +13,8 @@ export const QuoteDisplay = (props: Props) => {
   return (
     <div>
       <h2>Quote</h2>
+      {quote.acreageRateDescription}: {quote.acres} @ {formatCurrency(quote.acreageRate)} = ${formatCurrency(quote.acreageTotal)}
+      <hr/>
       {quote.activities.map((activity) => (
         <div key={`${activity.name}-${activity.id}`}>
           <h2>

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -55,6 +55,8 @@ export class QuoteContentImpl implements QuoteContent {
   projectName = ""; // TODO: might be worth removing when feasible
   acres = 0;
   acreageRate = 360;
+  acreageRateId = 0;
+  acreageRateDescription = "";
   total = 0;
   acreageTotal = 0;
   activitiesTotal = 0;
@@ -70,6 +72,8 @@ export interface QuoteContent {
   projectName: string; // TODO: might be worth removing when feasible
   acres: number;
   acreageRate: number;
+  acreageRateId: number;
+  acreageRateDescription: string;
   activities: Activity[];
   total: number;
   acreageTotal: number;

--- a/Harvest.Web/Controllers/Api/RequestController.cs
+++ b/Harvest.Web/Controllers/Api/RequestController.cs
@@ -70,6 +70,8 @@ namespace Harvest.Web.Controllers
 
             project.Accounts = new List<Account>(model.Accounts);
             project.Status = "PendingAccountApproval"; // TODO: update with enumerated values
+            project.QuoteId = quote.Id;
+            project.QuoteTotal = quote.Total;
 
             // TODO: Maybe inactivate instead?
             // remove any existing accounts that we no longer need

--- a/Harvest.Web/Controllers/Api/RequestController.cs
+++ b/Harvest.Web/Controllers/Api/RequestController.cs
@@ -41,13 +41,18 @@ namespace Harvest.Web.Controllers
 
         // Approve a quote for the project
         [HttpGet]
-        public ActionResult Approve(int id) {
+        public ActionResult Approve(int id)
+        {
             return View("React");
         }
 
         [HttpPost]
-        public async Task<ActionResult> ApproveAsync(int id, [FromBody]RequestApprovalModel model) {
+        public async Task<ActionResult> ApproveAsync(int id, [FromBody] RequestApprovalModel model)
+        {
             var project = await _dbContext.Projects.SingleAsync(p => p.Id == id);
+
+            // get the currently unapproved quote for this project
+            var quote = await _dbContext.Quotes.SingleAsync(q => q.ProjectId == id && q.ApprovedOn == null);
 
             // TODO: double check the percentages add up to 100%
             // TODO: add in fiscal officer info??
@@ -58,12 +63,17 @@ namespace Harvest.Web.Controllers
                 account.ApprovedOn = null;
             }
 
+            var quoteDetail = QuoteDetail.Deserialize(quote.Text);
+
+            project.Acres = quoteDetail.Acres;
+            project.AcreageRateId = quoteDetail.AcreageRateId;
+
             project.Accounts = new List<Account>(model.Accounts);
             project.Status = "PendingAccountApproval"; // TODO: update with enumerated values
 
             // TODO: Maybe inactivate instead?
             // remove any existing accounts that we no longer need
-            _dbContext.RemoveRange(_dbContext.Accounts.Where(x=>x.ProjectId == id));
+            _dbContext.RemoveRange(_dbContext.Accounts.Where(x => x.ProjectId == id));
 
             await _dbContext.SaveChangesAsync();
 
@@ -112,7 +122,8 @@ namespace Harvest.Web.Controllers
         }
     }
 
-    public class RequestApprovalModel {
+    public class RequestApprovalModel
+    {
         public Account[] Accounts { get; set; }
     }
 }

--- a/Harvest.Web/Models/QuoteModel.cs
+++ b/Harvest.Web/Models/QuoteModel.cs
@@ -23,6 +23,8 @@ namespace Harvest.Web.Models
         public string ProjectName { get; set; }
         public double Acres { get; set; }
         public double AcreageRate { get; set; }
+        public int AcreageRateId { get; set; }
+        public string AcreageRateDescription { get; set; }
         public double AcreageTotal { get; set; }
         public double ActivitiesTotal { get; set; }
         public double GrandTotal { get; set; }


### PR DESCRIPTION
Quote can now save additional acreage info and requires choosing an acreage from the rate table.  When that quote is approved, acreage info is set on the project along with a few other details we should have been doing all along.

closes #102