### PR TITLE
move leaflet to layout and remove react-specific pages

### DIFF
--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -26,7 +26,7 @@ namespace Harvest.Web.Controllers
         }
 
         public ActionResult Entry() {
-            return View();
+            return View("React");
         }
 
         [HttpPost]

--- a/Harvest.Web/Controllers/Api/QuoteController.cs
+++ b/Harvest.Web/Controllers/Api/QuoteController.cs
@@ -41,7 +41,7 @@ namespace Harvest.Web.Controllers
         [HttpGet]
         public ActionResult Create(int id)
         {
-            return View();
+            return View("React");
         }
 
         [HttpPost]

--- a/Harvest.Web/Views/Expense/Entry.cshtml
+++ b/Harvest.Web/Views/Expense/Entry.cshtml
@@ -1,3 +1,0 @@
-Expense Entry
-
-<div id="root"></div>

--- a/Harvest.Web/Views/Quote/Create.cshtml
+++ b/Harvest.Web/Views/Quote/Create.cshtml
@@ -1,5 +1,0 @@
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
-    integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
-    crossorigin="" />
-
-<div id="root"></div>

--- a/Harvest.Web/Views/Shared/_Layout.cshtml
+++ b/Harvest.Web/Views/Shared/_Layout.cshtml
@@ -16,6 +16,10 @@
         </cache>
     </environment>
 
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+    integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
+    crossorigin="" />
+
     @RenderSection("Styles", required: false)
 </head>
 


### PR DESCRIPTION
we'll load react for now via a shared react endpoint.  Eventually that will probably go away and we'll just route to react via startup.cs