### PR TITLE
Process invoices on first monday each month

### DIFF
--- a/Harvest.Jobs.Invoice/settings.job
+++ b/Harvest.Jobs.Invoice/settings.job
@@ -1,3 +1,3 @@
 {
-  "schedule": "0 0 13 * * *"
+  "schedule": "0 0 13 1-7 * Mon"
 }

--- a/Harvest.Jobs.Invoice/settings.job
+++ b/Harvest.Jobs.Invoice/settings.job
@@ -1,3 +1,3 @@
 {
-  "schedule": "0 0 13 1-7 * Mon"
+  "schedule": "0 0 13 * * Mon-Fri"
 }


### PR DESCRIPTION
Yep, it really is just a cron update: `0 0 13 1-7 * Mon` That translates to "1pm every day-of-month that falls within 1 through 7 and is a Monday".

Closes #161

Edit: Modified it to run every week day of month and the InvoiceService will determine if a given active project needs an invoice to be created on a given month. Wasn't sure if every day was appropriate or if it should just rerun for the first week. I don't see any harm either way.