### PR TITLE
Dynamically create fields by drawing shapes

### DIFF
--- a/Harvest.Web/ClientApp/package-lock.json
+++ b/Harvest.Web/ClientApp/package-lock.json
@@ -12615,6 +12615,22 @@
         "@react-leaflet/core": "^1.0.2"
       }
     },
+    "react-leaflet-draw": {
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.19.7.tgz",
+      "integrity": "sha512-wPjsoUYUrdwKX6zLcVdJmmqs18Nsdqy0VhsI5fvYvmTPTp5ZE4MSU9Zdyeion6lUaP8pEkWRizmLHCwbt1b5Mg==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "lodash-es": "^4.17.15"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
+      }
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",

--- a/Harvest.Web/ClientApp/package.json
+++ b/Harvest.Web/ClientApp/package.json
@@ -23,6 +23,7 @@
     "react-date-picker": "^8.1.1",
     "react-dom": "^17.0.1",
     "react-leaflet": "^3.1.0",
+    "react-leaflet-draw": "^0.19.7",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "react-table": "^7.7.0",

--- a/Harvest.Web/ClientApp/src/Fields/EditField.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/EditField.tsx
@@ -5,8 +5,9 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 import { Field } from "../types";
 
 interface Props {
+  crops: string[];
   field: Field;
-  saveFieldChanges: (field: Field) => void;
+  updateField: (field: Field) => void;
 }
 
 export const EditField = (props: Props) => {
@@ -27,19 +28,61 @@ export const EditField = (props: Props) => {
   return (
     <div>
       <Modal isOpen={isOpen}>
-        <ModalHeader>Modal title</ModalHeader>
+        <ModalHeader>Field #{props.field.id}</ModalHeader>
         <ModalBody>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat. Duis aute irure dolor in
-          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-          culpa qui officia deserunt mollit anim id est laborum.
+          <form>
+            <div className="form-group">
+              <label htmlFor="fieldName">Field Name</label>
+              <input
+                type="text"
+                className="form-control"
+                id="fieldName"
+                aria-describedby="fieldNameHelp"
+                value={props.field.name}
+                onChange={(e) =>
+                  props.updateField({ ...props.field, name: e.target.value })
+                }
+              />
+              <small id="fieldNameHelp" className="form-text text-muted">
+                A short, useful name to refer to this field later by
+              </small>
+            </div>
+            <div className="form-group">
+              <label htmlFor="crop">Crop</label>
+              <select
+                className="form-control"
+                id="crop"
+                defaultValue={props.field.crop}
+                onChange={(e) =>
+                  props.updateField({
+                    ...props.field,
+                    crop: e.target.value,
+                  })
+                }
+              >
+                {props.crops.map((crop) => (
+                  <option>{crop}</option>
+                ))}
+              </select>
+            </div>
+            <div className="form-group">
+              <label htmlFor="exampleFormControlTextarea1">Description</label>
+              <textarea
+                className="form-control"
+                id="exampleFormControlTextarea1"
+                placeholder="Optional description and notes specific to this field"
+                rows={3}
+                value={props.field.details}
+                onChange={(e) =>
+                  props.updateField({ ...props.field, details: e.target.value })
+                }
+              ></textarea>
+            </div>
+          </form>
         </ModalBody>
         <ModalFooter>
           <Button color="primary" onClick={update}>
-            Do Something
+            Close
           </Button>
         </ModalFooter>
       </Modal>

--- a/Harvest.Web/ClientApp/src/Fields/EditField.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/EditField.tsx
@@ -30,10 +30,11 @@ export const EditField = (props: Props) => {
       <Modal isOpen={isOpen}>
         <ModalHeader>Field #{props.field.id}</ModalHeader>
         <ModalBody>
-          <form>
+          <form onSubmit={e => e.preventDefault()}>
             <div className="form-group">
               <label htmlFor="fieldName">Field Name</label>
               <input
+                required
                 type="text"
                 className="form-control"
                 id="fieldName"
@@ -61,7 +62,7 @@ export const EditField = (props: Props) => {
                 }
               >
                 {props.crops.map((crop) => (
-                  <option>{crop}</option>
+                  <option key={crop}>{crop}</option>
                 ))}
               </select>
             </div>
@@ -82,7 +83,7 @@ export const EditField = (props: Props) => {
         </ModalBody>
         <ModalFooter>
           <Button color="primary" onClick={update}>
-            Close
+            Confirm
           </Button>
         </ModalFooter>
       </Modal>

--- a/Harvest.Web/ClientApp/src/Fields/EditField.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/EditField.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+
+import { Field } from "../types";
+
+interface Props {
+  field: Field;
+  saveFieldChanges: (field: Field) => void;
+}
+
+export const EditField = (props: Props) => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  // every time the field changes, re-open the modal
+  useEffect(() => {
+    setIsOpen(true);
+  }, [props.field]);
+
+  const update = () => {
+    if (props.field) {
+      //   props.saveFieldChanges({ ...props.field });
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <div>
+      <Modal isOpen={isOpen}>
+        <ModalHeader>Modal title</ModalHeader>
+        <ModalBody>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </ModalBody>
+        <ModalFooter>
+          <Button color="primary" onClick={update}>
+            Do Something
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </div>
+  );
+};

--- a/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
@@ -14,6 +14,7 @@ import {
 import { EditControl } from "react-leaflet-draw";
 
 import { EditField } from "./EditField";
+import { FieldPopup } from "./FieldPopup";
 import { Field } from "../types";
 
 interface Props {
@@ -70,6 +71,11 @@ export class FieldContainer extends React.Component<Props, State> {
     this.props.updateFields([...allItems]);
   };
 
+  _removeField = (field: Field) => {
+    const itemsToKeep = this.props.fields.filter((w) => w.id !== field.id);
+    this.props.updateFields(itemsToKeep);
+  };
+
   render() {
     return (
       <div>
@@ -105,7 +111,12 @@ export class FieldContainer extends React.Component<Props, State> {
           </FeatureGroup>
           {this.props.fields.map((field) => (
             <GeoJSON key={`field-${field.id}`} data={field.geometry}>
-              <Popup>Some content here</Popup>
+              <Popup>
+                <FieldPopup
+                  field={field}
+                  removeField={this._removeField}
+                ></FieldPopup>
+              </Popup>
             </GeoJSON>
           ))}
         </MapContainer>

--- a/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
@@ -1,3 +1,19 @@
+import React from "react";
+
+import {
+  MapContainer,
+  TileLayer,
+  Marker,
+  Popup,
+  GeoJSON,
+  FeatureGroup,
+} from "react-leaflet";
+
+// TODO: if we need to customize leaflet directly
+// import L from 'leaflet';
+
+import { EditControl } from "react-leaflet-draw";
+
 import { Field } from "../types";
 
 interface Props {
@@ -5,36 +21,84 @@ interface Props {
   updateFields: (fields: Field[]) => void;
 }
 
-export const FieldContainer = (props: Props) => {
-  const addDefaultField = () => {
-    const newId = Math.max(...props.fields.map((f) => f.id), 0) + 1;
+// NOTE: leaflet-draw plugin is not compatible with react hooks so we use a full component here
+export class FieldContainer extends React.Component<Props> {
+  _addDefaultField = (e: any) => {
+    const { layer } = e;
+    console.log(e);
+    console.log("creating field", this.props.fields);
+
+    const newId = Math.max(...this.props.fields.map((f) => f.id), 0) + 1;
     const newField: Field = {
       id: newId,
       name: "Default",
       crop: "Corn",
       details: "",
-      geometry: polyGeoJson, // TODO: for now just a hardcoded polygon
+      geometry: layer.toGeoJSON(), // TODO: for now just a hardcoded polygon
     };
 
-    props.updateFields([...props.fields, newField]);
-  };
-  return (
-    <div>
-      <button onClick={addDefaultField}>Add Sample Field</button>
-      (Eventually this will be map where you can set fields)
-    </div>
-  );
-};
+    this.props.updateFields([...this.props.fields, newField]);
 
-const polyGeoJson: GeoJSON.Polygon = {
-  type: "Polygon",
-  coordinates: [
-    [
-      [-121.7362572473126, 38.53441977139934],
-      [-121.7355166365403, 38.53441178558781],
-      [-121.7354814725578, 38.53455895851263],
-      [-121.7362224219185, 38.53454446823565],
-      [-121.7362572473126, 38.53441977139934],
-    ],
-  ],
-};
+    // immediately remove added layer because we are going to let react handle rendering layers
+    this._editableFG?.removeLayer(layer);
+  };
+
+  render() {
+    return (
+      <div>
+        <button onClick={this._addDefaultField}>Add Field</button>
+        <MapContainer
+          style={{ height: window.innerHeight }}
+          center={[38.5449, -121.7405]}
+          zoom={13}
+        >
+          <TileLayer
+            attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <FeatureGroup
+            ref={(reactFGref) => {
+              this._onFeatureGroupReady(reactFGref);
+            }}
+          >
+            <EditControl
+              position="topright"
+              onCreated={this._addDefaultField}
+              draw={{
+                polygon: {
+                  allowIntersection: false,
+                  showArea: true,
+                },
+                rectangle: true,
+                polyline: false,
+                circle: false,
+                circlemarker: false,
+                marker: false,
+              }}
+            />
+          </FeatureGroup>
+          {this.props.fields.map((field) => (
+            <GeoJSON key={`field-${field.id}`} data={field.geometry}>
+              <Popup>
+                Some content here
+              </Popup>
+            </GeoJSON>
+          ))}
+
+          <Marker position={[38.5449, -121.7405]}>
+            <Popup>
+              A pretty CSS3 popup. <br /> Easily customizable.
+            </Popup>
+          </Marker>
+        </MapContainer>
+      </div>
+    );
+  }
+
+  // our render feature group, only used for dynamic drawing
+  // once drawing is finished, a field is added and react-leaflet takes over with rendering and control
+  _editableFG: any = null;
+  _onFeatureGroupReady = (reactFGref: any) => {
+    this._editableFG = reactFGref;
+  };
+}

--- a/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
@@ -17,6 +17,7 @@ import { EditField } from "./EditField";
 import { Field } from "../types";
 
 interface Props {
+  crops: string[];
   fields: Field[];
   updateFields: (fields: Field[]) => void;
 }
@@ -43,8 +44,8 @@ export class FieldContainer extends React.Component<Props, State> {
     const newId = Math.max(...this.props.fields.map((f) => f.id), 0) + 1;
     const newField: Field = {
       id: newId,
-      name: "Default",
-      crop: "Corn",
+      name: `field-${newId}`,
+      crop: this.props.crops[0],
       details: "",
       geometry: layer.toGeoJSON(), // TODO: for now just a hardcoded polygon
     };
@@ -56,6 +57,17 @@ export class FieldContainer extends React.Component<Props, State> {
 
     // immediately remove added layer because we are going to let react handle rendering layers
     this._editableFG?.removeLayer(layer);
+  };
+
+  _updateField = (field: Field) => {
+    // TODO: can we get away without needing to spread copy?  do we need to totally splice/replace?
+    const allItems = this.props.fields;
+    const itemIndex = allItems.findIndex((a) => a.id === field.id);
+    allItems[itemIndex] = {
+      ...field,
+    };
+
+    this.props.updateFields([...allItems]);
   };
 
   render() {
@@ -109,7 +121,13 @@ export class FieldContainer extends React.Component<Props, State> {
       );
 
       if (field) {
-        return  <EditField field={field} saveFieldChanges={() => {}}></EditField>
+        return (
+          <EditField
+            crops={this.props.crops}
+            field={field}
+            updateField={this._updateField}
+          ></EditField>
+        );
       }
     }
 

--- a/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
@@ -48,7 +48,7 @@ export class FieldContainer extends React.Component<Props, State> {
       name: `field-${newId}`,
       crop: this.props.crops[0],
       details: "",
-      geometry: layer.toGeoJSON(), // TODO: for now just a hardcoded polygon
+      geometry: layer.toGeoJSON().geometry,
     };
 
     this.props.updateFields([...this.props.fields, newField]);

--- a/Harvest.Web/ClientApp/src/Fields/FieldPopup.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldPopup.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Field } from "../types";
+
+interface Props {
+  field: Field;
+  removeField: (field: Field) => void;
+}
+
+export const FieldPopup = (props: Props) => {
+  return (
+    <div>
+      <h2>{props.field.name}</h2>
+      <h2>{props.field.crop}</h2>
+      <p>{props.field.details}</p>
+      <button
+        className="btn btn-danger"
+        onClick={() => props.removeField(props.field)}
+      >
+        Remove
+      </button>
+    </div>
+  );
+};

--- a/Harvest.Web/ClientApp/src/Fields/Location.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/Location.tsx
@@ -1,21 +1,30 @@
 import React, { useMemo } from "react";
 import { MapContainer, TileLayer, GeoJSON } from "react-leaflet";
+
+import { getBoundingBox } from "../Util/Geography";
+
 import { Field } from "../types";
+import { LatLngBoundsExpression } from "leaflet";
 
 interface Props {
   fields: Field[];
 }
 
 export const Location = (props: Props) => {
-  // TODO: calculate center based on fields, or perhaps use bounds[] to set map just to include all fields
+  const bounds: LatLngBoundsExpression = useMemo(() => {
+    const bounds = getBoundingBox(props.fields.map((f) => f.geometry));
+    return [
+      [bounds.yMin, bounds.xMin],
+      [bounds.yMax, bounds.xMax],
+    ];
+  }, [props.fields]);
 
-  // TODO: use field data to determine center and then pass props.fields into dependency array
-  const center: any = useMemo(() => {
-    return [38.53441977139934, -121.7362572473126];
-  }, []);
+  if (!props.fields || props.fields.length === 0) {
+    return null;
+  }
 
   return (
-    <MapContainer style={{ height: 200 }} center={center} zoom={16}>
+    <MapContainer style={{ height: 200 }} bounds={bounds}>
       <TileLayer
         attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/Harvest.Web/ClientApp/src/Quotes/ProjectDetail.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ProjectDetail.tsx
@@ -20,6 +20,7 @@ interface Props {
   rates: Rate[];
   quote: QuoteContent;
   updateQuote: React.Dispatch<React.SetStateAction<QuoteContent>>;
+  setEditFields: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export const ProjectDetail = (props: Props) => {
@@ -168,7 +169,14 @@ export const ProjectDetail = (props: Props) => {
 
       {/* Right Details */}
       <Col md="6">
-        <Label for="projectLocation">Project Location</Label>
+        <Row>
+          <Col>
+            <Label for="projectLocation">Project Location</Label>
+          </Col>
+          <Col>
+            <button className="btn btn-link" onClick={_ => props.setEditFields(true)}>Edit Fields</button>
+          </Col>
+        </Row>
         <Location fields={props.quote.fields}></Location>
         <br />
         <div id="map" />

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import {
@@ -62,7 +62,6 @@ export const QuoteContainer = () => {
     cb();
   }, [projectId]);
 
-
   useEffect(() => {
     setQuote((q) => {
       let acreageTotal = q.acreageRate * q.acres;
@@ -105,6 +104,10 @@ export const QuoteContainer = () => {
     });
   }, [quote.activities, quote.acreageRate, quote.acres]);
 
+  const cropArray = useMemo(() => (project ? project.crop.split(",") : []), [
+    project,
+  ]);
+
   const save = async () => {
     // TODO: add progress and hide info while saving
     const saveResponse = await fetch(`/Quote/Save/${projectId}`, {
@@ -128,12 +131,17 @@ export const QuoteContainer = () => {
   }
 
   // TODO: perhaps we might want to go back and modify the fields as well
-  if (quote.fields.length === 0) {
+  if (quote.fields.length < 3) {
     return (
-      <FieldContainer
-        fields={quote.fields}
-        updateFields={(fields) => setQuote({ ...quote, fields })}
-      ></FieldContainer>
+      <div>
+        <ProjectHeader project={project}></ProjectHeader>
+        <FieldContainer
+          crops={cropArray}
+          fields={quote.fields}
+          updateFields={(fields) => setQuote({ ...quote, fields })}
+        ></FieldContainer>
+        <div>Debug: {JSON.stringify(quote)}</div>
+      </div>
     );
   }
 

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -48,8 +48,7 @@ export const QuoteContainer = () => {
             fields: projectWithQuote.quote.fields ?? [],
           });
 
-          if (projectWithQuote.quote.fields.length === 0) {
-            // TODO: i'm not sure it's possible for a quote to have no fields...
+          if (!projectWithQuote.quote.fields || projectWithQuote.quote.fields.length === 0) {
             setEditFields(true);
           }
         } else {
@@ -183,7 +182,7 @@ export const QuoteContainer = () => {
           <div className="quote-details">
             <h2>Quote Details</h2>
             <hr />
-            <ProjectDetail rates={rates} quote={quote} updateQuote={setQuote} />
+            <ProjectDetail rates={rates} quote={quote} updateQuote={setQuote} setEditFields={setEditFields} />
             <ActivitiesContainer
               quote={quote}
               rates={rates}

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -28,6 +28,8 @@ export const QuoteContainer = () => {
   const [quote, setQuote] = useState<QuoteContent>(new QuoteContentImpl());
   const [rates, setRates] = useState<Rate[]>([]);
 
+  const [editFields, setEditFields] = useState(false);
+
   useEffect(() => {
     const cb = async () => {
       const quoteResponse = await fetch(`/Quote/Get/${projectId}`);
@@ -45,6 +47,11 @@ export const QuoteContainer = () => {
             ...projectWithQuote.quote,
             fields: projectWithQuote.quote.fields ?? [],
           });
+
+          if (projectWithQuote.quote.fields.length === 0) {
+            // TODO: i'm not sure it's possible for a quote to have no fields...
+            setEditFields(true);
+          }
         } else {
           // TODO: how do we handle if different fields have different rates?
           const quoteToUse = new QuoteContentImpl();
@@ -52,6 +59,7 @@ export const QuoteContainer = () => {
             rateJson.find((r) => r.type === "Acreage")?.price || 120;
 
           setQuote(quoteToUse);
+          setEditFields(true); // we have no existing quote, start with editing fields
         }
       } else {
         !quoteResponse.ok && console.error(quoteResponse);
@@ -130,11 +138,33 @@ export const QuoteContainer = () => {
     return <div>Loading</div>;
   }
 
-  // TODO: perhaps we might want to go back and modify the fields as well
-  if (quote.fields.length < 3) {
+  // TODO: we might want to move this all into a separate component
+  if (editFields) {
     return (
       <div>
         <ProjectHeader project={project}></ProjectHeader>
+        <div>
+          <h3>Choose a location</h3>
+          Instructions:
+          <ol>
+            <li>
+              Draw your field boundaries using the rectangle or polygon tool in
+              the upper-right
+            </li>
+            <li>Fill in the field details and click "Confirm"</li>
+            <li>
+              You can add in as many fields as you like, or click an existing
+              field for more info and actions
+            </li>
+            <li>When you are finished, click confirm below</li>
+          </ol>
+          <button
+            className="btn btn-primary"
+            onClick={(_) => setEditFields(false)}
+          >
+            Confirm Field Locations
+          </button>
+        </div>
         <FieldContainer
           crops={cropArray}
           fields={quote.fields}

--- a/Harvest.Web/ClientApp/src/Util/Geography.ts
+++ b/Harvest.Web/ClientApp/src/Util/Geography.ts
@@ -1,0 +1,36 @@
+import * as GeoJSON from "geojson";
+
+interface Bounds {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+}
+export const getBoundingBox = (polygons: GeoJSON.Polygon[]) => {
+  const bounds: Bounds = { } as Bounds;
+
+  for (let i = 0; i < polygons.length; i++) {
+    const coordinates = polygons[i].coordinates;
+
+    if (coordinates.length === 1) {
+      // It's only a single Polygon
+      // For each individual coordinate in this feature's coordinates...
+      for (let j = 0; j < coordinates[0].length; j++) {
+        let longitude = coordinates[0][j][0];
+        let latitude = coordinates[0][j][1];
+
+        // Update the bounds by comparing the current xMin/xMax and yMin/yMax with the current coordinate
+        bounds.xMin = bounds.xMin < longitude ? bounds.xMin : longitude;
+        bounds.xMax = bounds.xMax > longitude ? bounds.xMax : longitude;
+        bounds.yMin = bounds.yMin < latitude ? bounds.yMin : latitude;
+        bounds.yMax = bounds.yMax > latitude ? bounds.yMax : latitude;
+      }
+    } else {
+      console.log("multi-poly is unsupported");
+    }
+  }
+
+  // Returns an object that contains the bounds of this GeoJSON data.
+  // The keys describe a box formed by the northwest (xMin, yMin) and southeast (xMax, yMax) coordinates.
+  return bounds;
+};

--- a/Harvest.Web/Views/Shared/_Layout.cshtml
+++ b/Harvest.Web/Views/Shared/_Layout.cshtml
@@ -20,6 +20,9 @@
     integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
     crossorigin="" />
 
+    @* Optionally can be done by including node_modules/leaflet-draw/dist/leaflet.draw.css in module *@
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css"/>
+
     @RenderSection("Styles", required: false)
 </head>
 


### PR DESCRIPTION
When creating a new quote, or by clicking "edit fields" in a quote, you now go to field edit screen.  On the map you can add an arbitrary number of fields by using the polygon drawing icons.  A modal will then popup asking for details of that field.  Fields get saved to quote and are viewable via project location mini-map.

Cannot yet edit field (but can delete/re-add) and we still need to customize some draw controls, but the basic functionality is present.

closes #17