### PR TITLE
Swe/validation

### DIFF
--- a/Harvest.Web/ClientApp/package-lock.json
+++ b/Harvest.Web/ClientApp/package-lock.json
@@ -12814,6 +12814,11 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "react-use-form-state": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/react-use-form-state/-/react-use-form-state-0.13.2.tgz",
+      "integrity": "sha512-bP2H5V6bBFZCJIrbpUcahvJX/f5rGueOvIjg818sq3wg0aX6BFz70u81yhaSg2aCZq0aF3R8eMc2MRWIjr5yhw=="
+    },
     "reactstrap": {
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.9.0.tgz",
@@ -17288,6 +17293,11 @@
         "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       }
+    },
+    "zod": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.1.0.tgz",
+      "integrity": "sha512-qS0an8oo9EvVLVqIVxMZrQrfR2pVwBtlPp+BzTB/F19IyPTRaLLoFfdXRzgh626pxFR1efuTWV8bPoEE58KwqA=="
     }
   }
 }

--- a/Harvest.Web/ClientApp/package.json
+++ b/Harvest.Web/ClientApp/package.json
@@ -27,10 +27,12 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "react-table": "^7.7.0",
+    "react-use-form-state": "^0.13.2",
     "reactstrap": "^8.9.0",
     "typescript": "^4.2.2",
     "web-vitals": "^1.1.0",
-    "yup": "^0.32.9"
+    "yup": "^0.32.9",
+    "zod": "^3.1.0"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.7",

--- a/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
@@ -3,16 +3,16 @@ import {
   Button,
   Col,
   FormGroup,
-  Input,
   InputGroup,
   InputGroupAddon,
   InputGroupText,
   Row,
 } from "reactstrap";
-import { InputElement, useFormState, FormState, StateErrors } from 'react-use-form-state';
+import { useFormState, InputElement } from 'react-use-form-state';
 
 import { Rate, RateType, WorkItem, WorkItemSchema } from "../types";
 import { formatCurrency } from "../Util/NumberFormatting";
+import { getInputValidityStyle, getFieldValidator, ValidationErrorMessage } from "../Validation";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
@@ -35,21 +35,7 @@ interface WorkItemProps {
   deleteWorkItem: (workItem: WorkItem) => void;
 }
 
-interface ValidationMessageProps {
-  formState: FormState<any, StateErrors<any, string>>;
-  name: string;
-}
-
-const ValidationErrorMessage = (props: ValidationMessageProps) => {
-  const { formState, name } = props;
-  return formState.touched[name] && formState.validity[name] === false
-    ? (<p className="text-danger">{formState.errors[name]}</p>)
-    : (null);
-}
-
-const InputValidityStyle = (formState: FormState<any, StateErrors<any, string>>, name: string) => {
-  return formState.touched[name] && (formState.validity[name] === false) && "is-invalid";
-}
+const validateField = getFieldValidator(WorkItemSchema);
 
 const WorkItemForm = (props: WorkItemProps) => {
   const { workItem } = props;
@@ -68,16 +54,6 @@ const WorkItemForm = (props: WorkItemProps) => {
       }
     });
   console.debug(JSON.stringify(formState));
-
-  const validateField = (field: keyof WorkItem) =>
-    (value: unknown): string | true => {
-      const parsedResult = WorkItemSchema
-        .pick({ [field]: true })
-        .safeParse({ [field]: value });
-      return !parsedResult.success
-        ? parsedResult.error.errors[0].message
-        : true;
-    }
 
   // TODO: Determine a better way of working out which other options need extra description text
   const requiresCustomDescription = (unit: string | null) => {
@@ -109,7 +85,7 @@ const WorkItemForm = (props: WorkItemProps) => {
       <Col xs="5">
         <FormGroup>
           <select
-            className={`form-control ${InputValidityStyle(formState, "rateId")}`}
+            className={`form-control ${getInputValidityStyle(formState, "rateId")}`}
             {...select({
               name: "rateId",
               onChange: (e) => rateItemChanged(e, workItem),
@@ -125,7 +101,7 @@ const WorkItemForm = (props: WorkItemProps) => {
 
           {requiresCustomDescription(workItem.unit) && (
             <input
-              className={`form-control ${InputValidityStyle(formState, "description")}`}
+              className={`form-control ${getInputValidityStyle(formState, "description")}`}
               {...text({
                 name: "description",
                 validate: validateField("description")
@@ -143,7 +119,7 @@ const WorkItemForm = (props: WorkItemProps) => {
             <InputGroupText>{workItem.unit || ""}</InputGroupText>
           </InputGroupAddon>
           <input
-            className={`form-control ${InputValidityStyle(formState, "quantity")}`}
+            className={`form-control ${getInputValidityStyle(formState, "quantity")}`}
             {...number({
               name: "quantity",
               validate: (value) => validateField("quantity")(parseFloat(value))
@@ -158,7 +134,7 @@ const WorkItemForm = (props: WorkItemProps) => {
             <InputGroupText>$</InputGroupText>
           </InputGroupAddon>
           <input
-            className={`form-control ${InputValidityStyle(formState, "rate")}`}
+            className={`form-control ${getInputValidityStyle(formState, "rate")}`}
             {...number({
               name: "rate",
               validate: (value) => validateField("rate")(parseFloat(value))

--- a/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
@@ -9,8 +9,9 @@ import {
   InputGroupText,
   Row,
 } from "reactstrap";
+import { InputElement, useFormState, FormState, StateErrors } from 'react-use-form-state';
 
-import { Rate, RateType, WorkItem } from "../types";
+import { Rate, RateType, WorkItem, WorkItemSchema } from "../types";
 import { formatCurrency } from "../Util/NumberFormatting";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -25,34 +26,162 @@ interface Props {
   deleteWorkItem: (workItem: WorkItem) => void;
 }
 
-export const WorkItemsForm = (props: Props) => {
+interface WorkItemProps {
+  category: RateType;
+  rates: Rate[];
+  workItem: WorkItem;
+  updateWorkItems: (workItem: WorkItem) => void;
+  //addNewWorkItem: (type: RateType) => void;
+  deleteWorkItem: (workItem: WorkItem) => void;
+}
+
+interface ValidationMessageProps {
+  formState: FormState<any, StateErrors<any, string>>;
+  name: string;
+}
+
+const ValidationErrorMessage = (props: ValidationMessageProps) => {
+  const { formState, name } = props;
+  return formState.touched[name] && formState.validity[name] === false
+    ? (<p className="text-danger">{formState.errors[name]}</p>)
+    : (null);
+}
+
+const InputValidityStyle = (formState: FormState<any, StateErrors<any, string>>, name: string) => {
+  return formState.touched[name] && (formState.validity[name] === false) && "is-invalid";
+}
+
+const WorkItemForm = (props: WorkItemProps) => {
+  const { workItem } = props;
+
+  const [formState, { text, select, number }] = useFormState<WorkItem>(workItem,
+    {
+      onChange(e, stateValues, nextStateValues) {
+        const result = WorkItemSchema.safeParse({
+          ...nextStateValues,
+          rate: Number(nextStateValues.rate),
+          quantity: Number(nextStateValues.quantity)
+        });
+        if (result.success) {
+          props.updateWorkItems(result.data);
+        }
+      }
+    });
+  console.debug(JSON.stringify(formState));
+
+  const validateField = (field: keyof WorkItem) =>
+    (value: unknown): string | true => {
+      const parsedResult = WorkItemSchema
+        .pick({ [field]: true })
+        .safeParse({ [field]: value });
+      return !parsedResult.success
+        ? parsedResult.error.errors[0].message
+        : true;
+    }
+
+  // TODO: Determine a better way of working out which other options need extra description text
+  const requiresCustomDescription = (unit: string | null) => {
+    return props.category === "Other" && unit === "Unit";
+  };
+
   const rateItemChanged = (
-    e: React.ChangeEvent<HTMLInputElement>,
+    e: React.ChangeEvent<InputElement>,
     workItem: WorkItem
   ) => {
     const rateId = parseInt(e.target.value);
     const rate = props.rates.find((r) => r.id === rateId);
 
     // rate can be undefinied if they select the default option
-    if (rate !== undefined) {
+    if (!!rate) {
       // new rate selected, update the work item with defaults
-      props.updateWorkItems({
-        ...workItem,
-        description: requiresCustomDescription(rate.unit)
-          ? ""
-          : rate.description,
-        rateId,
-        rate: rate.price,
-        unit: rate.unit,
-        total: 0,
-      });
+      formState.setField("rateId", rateId);
+      formState.setField("rate", rate.price);
+      formState.setField("description", requiresCustomDescription(rate.unit) ? "" : rate.description);
+      formState.setField("unit", rate.unit);
+      formState.setField("total", 0);
     }
   };
 
-  // TODO: Determine a better way of working out which other options need extra description text
-  const requiresCustomDescription = (unit: string) => {
-    return props.category === "Other" && unit === "Unit";
-  };
+  return (
+    <Row
+      className="activity-line-item"
+      key={`workItem-${workItem.id}-activity-${workItem.activityId}`}>
+      <Col xs="5">
+        <FormGroup>
+          <select
+            className={`form-control ${InputValidityStyle(formState, "rateId")}`}
+            {...select({
+              name: "rateId",
+              onChange: (e) => rateItemChanged(e, workItem),
+              validate: (value) => validateField("rateId")(parseInt(value))
+            })}>
+            <option value="0">-- Select {props.category} --</option>
+            {props.rates.map((r) => (
+              <option key={`rate-${r.type}-${r.id}`} value={r.id}>
+                {r.description}
+              </option>
+            ))}
+          </select>
+
+          {requiresCustomDescription(workItem.unit) && (
+            <input
+              className={`form-control ${InputValidityStyle(formState, "description")}`}
+              {...text({
+                name: "description",
+                validate: validateField("description")
+              })}
+            ></input>
+          )}
+        </FormGroup>
+        <ValidationErrorMessage formState={formState} name="rateId" />
+        <ValidationErrorMessage formState={formState} name="description" />
+      </Col>
+
+      <Col xs="3">
+        <InputGroup>
+          <InputGroupAddon addonType="prepend">
+            <InputGroupText>{workItem.unit || ""}</InputGroupText>
+          </InputGroupAddon>
+          <input
+            className={`form-control ${InputValidityStyle(formState, "quantity")}`}
+            {...number({
+              name: "quantity",
+              validate: (value) => validateField("quantity")(parseFloat(value))
+            })} />
+        </InputGroup>
+        <ValidationErrorMessage formState={formState} name="quantity" />
+      </Col>
+
+      <Col xs="2">
+        <InputGroup>
+          <InputGroupAddon addonType="prepend">
+            <InputGroupText>$</InputGroupText>
+          </InputGroupAddon>
+          <input
+            className={`form-control ${InputValidityStyle(formState, "rate")}`}
+            {...number({
+              name: "rate",
+              validate: (value) => validateField("rate")(parseFloat(value))
+            })} />
+        </InputGroup>
+        <ValidationErrorMessage formState={formState} name="rate" />
+      </Col>
+
+      <Col xs="1">${formatCurrency(workItem.rate * workItem.quantity)}</Col>
+
+      <Col xs="1">
+        <button
+          className="btn btn-link"
+          onClick={() => props.deleteWorkItem(workItem)}>
+          <FontAwesomeIcon icon={faTrashAlt} />
+        </button>
+      </Col>
+    </Row>
+  );
+}
+
+export const WorkItemsForm = (props: Props) => {
+
 
   return (
     <div className="activity-line">
@@ -70,93 +199,7 @@ export const WorkItemsForm = (props: Props) => {
           <label>Total</label>
         </Col>
       </Row>
-      {props.workItems.map((workItem) => (
-        <Row
-          className="activity-line-item"
-          key={`workItem-${workItem.id}-activity-${workItem.activityId}`}
-        >
-          <Col xs="5">
-            <FormGroup>
-              <Input
-                type="select"
-                name="select"
-                defaultValue={workItem.rateId}
-                onChange={(e) => rateItemChanged(e, workItem)}
-              >
-                <option value="0">-- Select {props.category} --</option>
-                {props.rates.map((r) => (
-                  <option key={`rate-${r.type}-${r.id}`} value={r.id}>
-                    {r.description}
-                  </option>
-                ))}
-              </Input>
-              {requiresCustomDescription(workItem.unit) && (
-                <Input
-                  type="text"
-                  name="OtherDescription"
-                  value={workItem.description}
-                  placeholder="Description"
-                  onChange={(e) =>
-                    props.updateWorkItems({
-                      ...workItem,
-                      description: e.target.value,
-                    })
-                  }
-                ></Input>
-              )}
-            </FormGroup>
-          </Col>
-
-          <Col xs="3">
-            <InputGroup>
-              <InputGroupAddon addonType="prepend">
-                <InputGroupText>{workItem.unit || ""}</InputGroupText>
-              </InputGroupAddon>
-              <Input
-                type="number"
-                id="units"
-                value={workItem.quantity}
-                onChange={(e) =>
-                  props.updateWorkItems({
-                    ...workItem,
-                    quantity: parseFloat(e.target.value ?? 0),
-                  })
-                }
-              />
-            </InputGroup>
-          </Col>
-
-          <Col xs="2">
-            <InputGroup>
-              <InputGroupAddon addonType="prepend">
-                <InputGroupText>$</InputGroupText>
-              </InputGroupAddon>
-              <Input
-                type="number"
-                id="rate"
-                value={workItem.rate}
-                onChange={(e) =>
-                  props.updateWorkItems({
-                    ...workItem,
-                    rate: parseFloat(e.target.value ?? 0),
-                  })
-                }
-              />
-            </InputGroup>
-          </Col>
-
-          <Col xs="1">${formatCurrency(workItem.rate * workItem.quantity)}</Col>
-
-          <Col xs="1">
-            <button
-              className="btn btn-link"
-              onClick={() => props.deleteWorkItem(workItem)}
-            >
-              <FontAwesomeIcon icon={faTrashAlt} />
-            </button>
-          </Col>
-        </Row>
-      ))}
+      {props.workItems.map((workItem) => <WorkItemForm workItem={workItem} {...props} />)}
       <Button
         className="btn-sm"
         color="link"

--- a/Harvest.Web/ClientApp/src/Validation/index.tsx
+++ b/Harvest.Web/ClientApp/src/Validation/index.tsx
@@ -1,0 +1,32 @@
+﻿import React from "react";
+import { InputElement, useFormState, FormState, StateErrors } from "react-use-form-state";
+import { z, ZodObject } from "Zod";
+
+interface ValidationMessageProps {
+  formState: FormState<any, StateErrors<any, string>>;
+  name: string;
+}
+
+export const ValidationErrorMessage = (props: ValidationMessageProps) => {
+  const { formState, name } = props;
+  return formState.touched[name] && formState.validity[name] === false
+    ? (<p className="text-danger">{formState.errors[name]}</p>)
+    : (null);
+}
+
+export const getInputValidityStyle = (formState: FormState<any, StateErrors<any, string>>, name: string) => {
+  return formState.touched[name] && (formState.validity[name] === false) && "is-invalid";
+}
+
+export function getFieldValidator<T extends ZodObject<any>>(schema: T) {
+  return (field: keyof any) => {
+    return (value: unknown): string | true => {
+      const parsedResult = schema
+        .pick({ [field]: true })
+        .safeParse({ [field]: value });
+      return !parsedResult.success
+        ? parsedResult.error.errors[0].message
+        : true;
+    }
+  }
+}

--- a/Harvest.Web/ClientApp/src/Validation/index.tsx
+++ b/Harvest.Web/ClientApp/src/Validation/index.tsx
@@ -1,6 +1,6 @@
 ﻿import React from "react";
 import { InputElement, useFormState, FormState, StateErrors } from "react-use-form-state";
-import { z, ZodObject } from "Zod";
+import { z, ZodObject } from "zod";
 
 interface ValidationMessageProps {
   formState: FormState<any, StateErrors<any, string>>;

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export type CropType = "Row" | "Tree"
 export type RateType = "Acreage" | "Equipment" | "Labor" | "Other"
 
@@ -171,17 +173,20 @@ export class WorkItemImpl implements WorkItem {
     this.unit = "";
   }
 }
-export interface WorkItem {
-  id: number;
-  activityId: number;
-  type: RateType;
-  rateId: number;
-  rate: number;
-  description: string;
-  quantity: number;
-  unit: string;
-  total: number;
-}
+
+export const WorkItemSchema = z.object({
+  id: z.number().int().default(0),
+  activityId: z.number().int(),
+  type: z.union([z.literal("Acreage"), z.literal("Equipment"), z.literal("Labor"), z.literal("Other")]),
+  rateId: z.number().int().default(0),
+  rate: z.number().min(0),
+  description: z.string(),
+  quantity: z.number().min(0),
+  unit: z.string().nullable(),
+  total: z.number().min(0)
+});
+
+export interface WorkItem extends z.infer<typeof WorkItemSchema> {};
 
 export interface Activity {
   total: number;


### PR DESCRIPTION
Here's a proof-of-concept using Zod and react-use-form-state. The only annoying thing I've found so far with Zod is that transformations occur after parsing, which means you can't parse a numeric string to a number type. One would have to do something even more janky than my workaround like define the target property as a number | string union to allow such. That's why you'll see a few `parseInt`s and `Number()`'s in the form.