### PR TITLE
Client-side file upload

### DIFF
--- a/Harvest.Web/ClientApp/package-lock.json
+++ b/Harvest.Web/ClientApp/package-lock.json
@@ -4,6 +4,177 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/abort-controller": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
+      "integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@azure/core-asynciterator-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+    },
+    "@azure/core-auth": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.0.tgz",
+      "integrity": "sha512-kSDSZBL6c0CYdhb+7KuutnKGf2geeT+bCJAgccB0DD7wmNJSsQPcF7TcuoZX83B7VK4tLz/u+8sOO/CnCsYp8A==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@azure/core-http": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.6.tgz",
+      "integrity": "sha512-odtH7UMKtekc5YQ86xg9GlVHNXR6pq2JgJ5FBo7/jbOjNGdBqcrIVrZx2bevXVJz/uUTSx6vUf62gzTXTfqYSQ==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-asynciterator-polyfill": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-tracing": "1.0.0-preview.11",
+        "@azure/logger": "^1.0.0",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.1",
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0",
+        "process": "^0.11.10",
+        "tough-cookie": "^4.0.0",
+        "tslib": "^2.2.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^8.3.0",
+        "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "tough-cookie": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+          "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+          "requires": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.1.2"
+          }
+        },
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
+      }
+    },
+    "@azure/core-lro": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-1.0.5.tgz",
+      "integrity": "sha512-0EFCFZxARrIoLWMIRt4vuqconRVIO2Iin7nFBfJiYCCbKp5eEmxutNk8uqudPmG0XFl5YqlVh68/al/vbE5OOg==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.2.0",
+        "@azure/core-tracing": "1.0.0-preview.11",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@azure/core-paging": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.3.tgz",
+      "integrity": "sha512-his7Ah40ThEYORSpIAwuh6B8wkGwO/zG7gqVtmSE4WAJ46e36zUDXTKReUCLBDc6HmjjApQQxxcRFy5FruG79A==",
+      "requires": {
+        "@azure/core-asynciterator-polyfill": "^1.0.0"
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.0.0-preview.11",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.11.tgz",
+      "integrity": "sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==",
+      "requires": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/api": "1.0.0-rc.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@azure/logger": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.2.tgz",
+      "integrity": "sha512-YZNjNV0vL3nN2nedmcjQBcpCTo3oqceXmgiQtEm6fLpucjRZyQKAQruhCmCpRlB1iykqKJJ/Y8CDmT5rIE6IJw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@azure/storage-blob": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.6.0.tgz",
+      "integrity": "sha512-cAzsae+5ZdhugQfIT7o5SlVyF2Sc+HygZdPO41ZYdXklfGUyEt+5K4PyM5HQDc0MTVt6x7+waXcaAXT2eF9E6A==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.2.0",
+        "@azure/core-lro": "^1.0.2",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-tracing": "1.0.0-preview.11",
+        "@azure/logger": "^1.0.0",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
@@ -1703,6 +1874,16 @@
         }
       }
     },
+    "@opencensus/web-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
+    },
+    "@opentelemetry/api": {
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
+      "integrity": "sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ=="
+    },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
@@ -2131,6 +2312,27 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
       "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
+      "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -2246,6 +2448,14 @@
       "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
       "requires": {
         "@types/jest": "*"
+      }
+    },
+    "@types/tunnel": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/uglify-js": {
@@ -10132,6 +10342,11 @@
         }
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -15316,6 +15531,11 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -17204,6 +17424,22 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+          "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+        }
+      }
     },
     "xmlbuilder": {
       "version": "15.1.1",

--- a/Harvest.Web/ClientApp/package-lock.json
+++ b/Harvest.Web/ClientApp/package-lock.json
@@ -2466,6 +2466,12 @@
         "source-map": "^0.6.1"
       }
     },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "dev": true
+    },
     "@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",

--- a/Harvest.Web/ClientApp/package.json
+++ b/Harvest.Web/ClientApp/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@azure/storage-blob": "^12.6.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.34",
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@fortawesome/react-fontawesome": "^0.1.14",

--- a/Harvest.Web/ClientApp/package.json
+++ b/Harvest.Web/ClientApp/package.json
@@ -30,6 +30,7 @@
     "react-table": "^7.7.0",
     "reactstrap": "^8.9.0",
     "typescript": "^4.2.2",
+    "uuid": "^8.3.2",
     "web-vitals": "^1.1.0",
     "yup": "^0.32.9"
   },
@@ -39,6 +40,7 @@
     "@types/react-bootstrap-typeahead": "^5.1.4",
     "@types/react-router-dom": "^5.1.7",
     "@types/react-table": "^7.0.29",
+    "@types/uuid": "^8.3.0",
     "cross-env": "^7.0.3",
     "eslint-config-prettier": "^8.2.0",
     "jest-trx-results-processor": "^2.2.0",

--- a/Harvest.Web/ClientApp/src/Requests/FileUpload.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/FileUpload.tsx
@@ -4,9 +4,9 @@ import { v4 as uuidv4 } from "uuid";
 import { BlobServiceClient } from "@azure/storage-blob";
 
 interface Props {
-  files: File[];
-  setFiles: (files: File[]) => void;
-  updateFile: (file: File) => void;
+  files: BlobFile[];
+  setFiles: (files: BlobFile[]) => void;
+  updateFile: (file: BlobFile) => void;
 }
 
 const UploadFile = async (
@@ -49,7 +49,7 @@ export const FileUpload = (props: Props) => {
     // shouldn't be possible, but we can't upload any files if we don't have the SAS info yet
     if (sasUrl === undefined || addedFiles === null) return;
 
-    const newFiles: File[] = [];
+    const newFiles: BlobFile[] = [];
 
     for (let i = 0; i < addedFiles.length; i++) {
       const addedFile = addedFiles[i];
@@ -104,7 +104,7 @@ export const FileUpload = (props: Props) => {
   );
 };
 
-interface File {
+interface BlobFile {
   id: string;
   name: string;
   size: number;

--- a/Harvest.Web/ClientApp/src/Requests/FileUpload.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/FileUpload.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+
+export const FileUpload = () => {
+  // TODO: pass uploaded files up to parent.  perhaps allow add/remove
+  const [files, setFiles] = useState<File[]>([]);
+
+  const filesChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const addedFiles = event.target.files;
+
+    if (addedFiles == null) {
+      return;
+    }
+
+    console.log(addedFiles);
+
+    const newFiles: File[] = [];
+
+    for (let i = 0; i < addedFiles.length; i++) {
+      const addedFile = addedFiles[i];
+
+      // TODO: make file name unique w/ GUID or similar
+      newFiles.push({
+        name: addedFile.name,
+        size: addedFile.size,
+        type: addedFile.type,
+        uploaded: false,
+      });
+    }
+
+    setFiles((f) => [...f, ...newFiles]);
+  };
+
+  return (
+    <div>
+      <input
+        type="file"
+        multiple={true}
+        className="form-control-file"
+        onChange={filesChanged}
+      />
+      {files.length > 0 && (
+        <small id="emailHelp" className="form-text text-muted">
+          <ul>
+            {files.map((file) => (
+              <li key={file.name}>{file.name} {!file.uploaded && '[spinner]'}</li>
+            ))}
+          </ul>
+        </small>
+      )}
+    </div>
+  );
+};
+
+interface File {
+  name: string;
+  size: number;
+  type: string;
+  uploaded: boolean;
+}

--- a/Harvest.Web/ClientApp/src/Requests/FileUpload.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/FileUpload.tsx
@@ -1,17 +1,50 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+
+import { BlobServiceClient } from "@azure/storage-blob";
+
+const UploadFile = async (
+  sasUrl: string,
+  fileName: string,
+  dataPromise: Promise<ArrayBuffer>
+) => {
+  const blobServiceClient = new BlobServiceClient(sasUrl);
+
+  const containerClient = blobServiceClient.getContainerClient("");
+  const blockClient = containerClient.getBlockBlobClient(fileName);
+
+  const data = await dataPromise;
+  const uploadBlobResponse = await blockClient.uploadData(data);
+
+  return uploadBlobResponse;
+};
 
 export const FileUpload = () => {
   // TODO: pass uploaded files up to parent.  perhaps allow add/remove
   const [files, setFiles] = useState<File[]>([]);
+  const [sasUrl, setSasUrl] = useState<string>();
+
+  useEffect(() => {
+    // grab the sas token right away
+    const cb = async () => {
+      const response = await fetch(`/File/GetUploadDetails`);
+
+      if (response.ok) {
+        setSasUrl(await response.text());
+      }
+    };
+
+    cb();
+  }, []);
 
   const filesChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
+    // shouldn't be possible, but we can't upload any files if we don't have the SAS info yet
+    if (sasUrl === undefined) return;
+
     const addedFiles = event.target.files;
 
     if (addedFiles == null) {
       return;
     }
-
-    console.log(addedFiles);
 
     const newFiles: File[] = [];
 
@@ -19,16 +52,36 @@ export const FileUpload = () => {
       const addedFile = addedFiles[i];
 
       // TODO: make file name unique w/ GUID or similar
+      const name = addedFile.name;
+
       newFiles.push({
-        name: addedFile.name,
+        name: name,
         size: addedFile.size,
         type: addedFile.type,
         uploaded: false,
+      });
+
+      console.log('uploading with ', sasUrl)
+
+      UploadFile(sasUrl, name, addedFile.arrayBuffer()).then((_) => {
+        // TODO, check for an error
+
+        // file is done uploading, so update uploaded details
+        setFiles((f) => {
+          const fileIndex = f.findIndex((file) => file.name === name);
+          f[fileIndex].uploaded = true;
+
+          return [...f];
+        });
       });
     }
 
     setFiles((f) => [...f, ...newFiles]);
   };
+
+  if (sasUrl === undefined) {
+    return <></>;
+  }
 
   return (
     <div>
@@ -42,7 +95,9 @@ export const FileUpload = () => {
         <small id="emailHelp" className="form-text text-muted">
           <ul>
             {files.map((file) => (
-              <li key={file.name}>{file.name} {!file.uploaded && '[spinner]'}</li>
+              <li key={file.name}>
+                {file.name} {!file.uploaded && "[spinner]"}
+              </li>
             ))}
           </ul>
         </small>

--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
@@ -188,7 +188,18 @@ export const RequestContainer = () => {
 
         <FormGroup>
           <Label>Want to attach any files?</Label>
-          <FileUpload></FileUpload>
+          <FileUpload
+            files={project.files || []}
+            setFiles={(f) => setProject({ ...project, files: [...f] })}
+            updateFile={(f) =>
+              setProject((proj) => {
+                // update just one specific file from project p
+                proj.files[proj.files.findIndex(file=>file.id === f.id)] = {...f};
+                
+                return { ...proj, files: [...proj.files] };
+              })
+            }
+          ></FileUpload>
         </FormGroup>
 
         <FormGroup>

--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
@@ -4,6 +4,7 @@ import { Button, FormGroup, Input, Label } from "reactstrap";
 import { ValidationError } from "yup";
 import DatePicker from "react-date-picker";
 
+import { FileUpload } from "./FileUpload";
 import { SearchPerson } from "./SearchPerson";
 import { Crops } from "./Crops";
 import { requestSchema } from "../schemas";
@@ -47,7 +48,9 @@ export const RequestContainer = () => {
       }
     };
 
-    cb();
+    if (projectId !== undefined) {
+      cb();
+    }
   }, [projectId]);
 
   const create = async () => {
@@ -181,6 +184,11 @@ export const RequestContainer = () => {
               setProject({ ...project, principalInvestigator: u })
             }
           ></SearchPerson>
+        </FormGroup>
+
+        <FormGroup>
+          <Label>Want to attach any files?</Label>
+          <FileUpload></FileUpload>
         </FormGroup>
 
         <FormGroup>

--- a/Harvest.Web/ClientApp/src/Test/mockData.ts
+++ b/Harvest.Web/ClientApp/src/Test/mockData.ts
@@ -39,6 +39,7 @@ export const fakeProject: ProjectWithQuote = {
     },
     accounts: null,
     quotes: null,
+    files: []
   },
   quote: null,
 };

--- a/Harvest.Web/ClientApp/src/schemas.ts
+++ b/Harvest.Web/ClientApp/src/schemas.ts
@@ -1,6 +1,6 @@
 import * as yup from "yup";
 import { SchemaOf } from "yup";
-import { RequestInput, User } from "./types";
+import { BlobFile, RequestInput, User } from "./types";
 
 export const investigatorSchema: SchemaOf<User> = yup
   .object()
@@ -15,6 +15,14 @@ export const investigatorSchema: SchemaOf<User> = yup
     nameAndEmail: yup.string(),
   });
 
+export const fileSchema: SchemaOf<BlobFile> = yup.object().shape({
+  id: yup.string().required(),
+  name: yup.string().required(),
+  size: yup.number().required(),
+  type: yup.string().required(),
+  uploaded: yup.boolean().required().isTrue() // files are only valid if they are done uploading
+});
+
 export const requestSchema: SchemaOf<RequestInput> = yup.object().shape({
   id: yup.number().required(),
   start: yup.string().required(),
@@ -23,4 +31,5 @@ export const requestSchema: SchemaOf<RequestInput> = yup.object().shape({
   cropType: yup.string().required(),
   requirements: yup.string(),
   principalInvestigator: investigatorSchema,
+  files: yup.array().of(fileSchema)
 });

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -23,6 +23,15 @@ export interface Project {
   isActive: boolean;
   accounts: null;
   quotes: null;
+  files: File[];
+}
+
+export interface File {
+  id: string;
+  name: string;
+  size: number;
+  type: string;
+  uploaded: boolean;
 }
 
 export interface Invoice {

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -23,10 +23,10 @@ export interface Project {
   isActive: boolean;
   accounts: null;
   quotes: null;
-  files: File[];
+  files: BlobFile[];
 }
 
-export interface File {
+export interface BlobFile {
   id: string;
   name: string;
   size: number;
@@ -223,6 +223,7 @@ export interface RequestInput {
   cropType: string;
   requirements?: string;
   principalInvestigator: User;
+  files: BlobFile[];
 }
 
 export interface ProjectWithInvoice {

--- a/Harvest.Web/Controllers/Api/FileController.cs
+++ b/Harvest.Web/Controllers/Api/FileController.cs
@@ -20,15 +20,16 @@ namespace Harvest.Web.Controllers
         }
 
         [HttpGet]
-        public Uri GetUploadUrl()
+        public string GetUploadDetails()
         {
-            return fileService.GetUploadUrl(storageSettings.ContainerName);
+            return fileService.GetUploadUrl(storageSettings.ContainerName).AbsoluteUri;
         }
 
         [HttpGet]
-        public Uri GetReadUrl() {
+        public string GetReadDetails()
+        {
             // TODO: need to know what blob they want to read
-            return fileService.GetDownloadUrl(storageSettings.ContainerName, "image.png");
+            return fileService.GetDownloadUrl(storageSettings.ContainerName, "image.png").AbsoluteUri;
         }
     }
 }


### PR DESCRIPTION
Client side of file upload v1 completed.  Doesn't save to db but this seemed like a good stopping point.  Uses the normal html file input to get files, uploads them to blob storage, and then tracks and validates they have been uploaded before allowing the user to click submit.  The file info is added to the project type so saving/retrieving should be simple from here.

part of #212