### PR TITLE
start of un-billed page with activity rehydrator 

### DIFF
--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -14,6 +14,7 @@ import { QuoteContainer } from "./Quotes/QuoteContainer";
 import { ProjectDetailContainer } from "./Projects/ProjectDetailContainer";
 import { ProjectListContainer } from "./Projects/ProjectListContainer";
 import { InvoiceDetailContainer } from "./Invoices/InvoiceDetailContainer";
+import { UnbilledExpensesContainer } from "./Expenses/UnbilledExpensesContainer";
 import { Map } from "./Maps/Map";
 
 
@@ -45,6 +46,7 @@ function App() {
         path="/expense/entry/:projectId?"
         component={ExpenseEntryContainer}
       />
+      <Route path="/expense/unbilled/:projectId" component={UnbilledExpensesContainer} />
       <Route path="/home/map" component={Map} />
     </AppContext.Provider>
   );

--- a/Harvest.Web/ClientApp/src/Expenses/UnbilledExpensesContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/UnbilledExpensesContainer.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { Activity, Expense, Rate, WorkItem } from "../types";
+
+interface RouteParams {
+  projectId?: string;
+}
+
+export const UnbilledExpensesContainer = () => {
+  const { projectId } = useParams<RouteParams>();
+
+  const [rates, setRates] = useState<Rate[]>([]);
+  const [activities, setActivities] = useState<Activity[]>([]);
+
+  useEffect(() => {
+    // get rates so we can load up all expense types and info
+    const cb = async () => {
+      const response = await fetch("/Rate/Active");
+
+      if (response.ok) {
+        const rates: Rate[] = await response.json();
+
+        setRates(rates);
+      }
+    };
+
+    cb();
+  }, []);
+
+  // Get all unbilled expenses for the given project and put them into activities
+  useEffect(() => {
+    if (projectId === undefined) return;
+
+    const cb = async () => {
+      const response = await fetch(`/Expense/GetUnbilled/${projectId}`);
+
+      if (response.ok) {
+        const expenses: Expense[] = await response.json();
+
+        if (expenses.length > 0) {
+          const uniqueActivities = Array.from(
+            new Set(expenses.map((e) => e.activity))
+          );
+
+          const activitiesWithWorkItems = uniqueActivities.map((val, idx) => {
+            const activityItems = expenses
+              .filter((e) => e.activity === val)
+              .map((e) => {
+                const itemRate = rates.find((r) => r.id === e.rateId);
+
+                const item = {
+                  activityId: idx,
+                  description: e.description,
+                  quantity: e.quantity,
+                  total: e.total,
+                  rate: e.price,
+                  rateId: e.rateId,
+                  unit: itemRate?.unit, // TODO: we should probably just store unit in the db
+                  type: e.type,
+                } as WorkItem;
+
+                return item;
+              });
+            const total = activityItems.reduce(
+              (prev, curr) => prev + curr.total,
+              0
+            );
+
+            const activity: Activity = {
+              id: idx,
+              name: val,
+              total,
+              workItems: activityItems,
+            };
+
+            return activity;
+          });
+
+          setActivities(activitiesWithWorkItems);
+        } else {
+          setActivities([]);
+        }
+      }
+    };
+
+    cb();
+  }, [projectId, rates]);
+
+  return (
+    <div>
+      <h3>Unbilled!</h3>
+      {projectId}
+      {JSON.stringify(activities)}
+    </div>
+  );
+};

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -29,6 +29,10 @@ namespace Harvest.Web.Controllers
             return View("React");
         }
 
+        public ActionResult Unbilled(int id) {
+            return View("React");
+        }
+
         [HttpPost]
         [Authorize(Policy = AccessCodes.DepartmentAdminAccess)]
         [Consumes(MediaTypeNames.Application.Json)]
@@ -51,6 +55,12 @@ namespace Harvest.Web.Controllers
             await _dbContext.SaveChangesAsync();
 
             return Ok(expenses);
+        }
+
+        // Get all unbilled expenses for the given project
+        [HttpGet]
+        public async Task<ActionResult> GetUnbilled(int id) {
+            return Ok(await _dbContext.Expenses.Where(e=>e.InvoiceId == null && e.ProjectId == id).ToArrayAsync());
         }
     }
 }


### PR DESCRIPTION
I'm having second thoughts on making the unbilled expenses all editable.  I think it'll be quite doable technologically but it'll loose the history of who created the expense and we don't have editor tracking.  Perhaps it would be better to just display the expenses and then allow deleting and maybe single-item editing, since hopefully you shouldn't be regularly bulk-editing all of your already entered expenses.

This PR so far contains some nice code for returning unbilled expenses data and transforming them into activities, so I don't want to loose it.  But let's all talk about how we want to handle this before I got any futher.  Part of #219.