### PR TITLE
default to projectId for most routes

### DIFF
--- a/Harvest.Web/ClientApp/src/Expenses/UnbilledExpensesContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/UnbilledExpensesContainer.tsx
@@ -36,7 +36,7 @@ export const UnbilledExpensesContainer = () => {
 
   // This function closes the modal and deletes the entry from the db
   const confirmModal = async (expenseId: number) => {
-    const response = await fetch(`/Expense/Delete/${expenseId}`, {
+    const response = await fetch(`/Expense/Delete?expenseId=${expenseId}`, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -38,7 +38,7 @@ namespace Harvest.Web.Controllers
         [HttpPost]
         [Authorize(Policy = AccessCodes.DepartmentAdminAccess)]
         [Consumes(MediaTypeNames.Application.Json)]
-        public async Task<ActionResult> Create(int id, [FromBody] Expense[] expenses)
+        public async Task<ActionResult> Create(int projectId, [FromBody] Expense[] expenses)
         {
             // TODO: validation!
             var user = await _userService.GetCurrentUser();
@@ -47,7 +47,7 @@ namespace Harvest.Web.Controllers
             {
                 expense.CreatedBy = user;
                 expense.CreatedOn = DateTime.UtcNow;
-                expense.ProjectId = id;
+                expense.ProjectId = projectId;
                 expense.InvoiceId = null;
                 expense.Account = allRates.Single(a => a.Id == expense.RateId).Account;
             }
@@ -61,8 +61,8 @@ namespace Harvest.Web.Controllers
 
         [HttpPost]
         [Authorize(Policy = AccessCodes.SupervisorAccess)]
-        public async Task<ActionResult> Delete(int id) {
-            var expense = await _dbContext.Expenses.FindAsync(id);
+        public async Task<ActionResult> Delete(int expenseId) {
+            var expense = await _dbContext.Expenses.FindAsync(expenseId);
 
             if (expense == null) {
                 return NotFound();
@@ -76,16 +76,16 @@ namespace Harvest.Web.Controllers
 
         // Get all unbilled expenses for the given project
         [HttpGet]
-        public async Task<ActionResult> GetUnbilled(int id)
+        public async Task<ActionResult> GetUnbilled(int projectId)
         {
-            return Ok(await _dbContext.Expenses.Include(e => e.CreatedBy).Where(e => e.InvoiceId == null && e.ProjectId == id).ToArrayAsync());
+            return Ok(await _dbContext.Expenses.Include(e => e.CreatedBy).Where(e => e.InvoiceId == null && e.ProjectId == projectId).ToArrayAsync());
         }
 
         // Get just the total of unbilled expenses for the current project
         [HttpGet]
-        public async Task<ActionResult> GetUnbilledTotal(int id)
+        public async Task<ActionResult> GetUnbilledTotal(int projectId)
         {
-            return Ok(await _dbContext.Expenses.Where(e => e.InvoiceId == null && e.ProjectId == id).SumAsync(e=>e.Total));
+            return Ok(await _dbContext.Expenses.Where(e => e.InvoiceId == null && e.ProjectId == projectId).SumAsync(e=>e.Total));
         }
     }
 }

--- a/Harvest.Web/Controllers/Api/QuoteController.cs
+++ b/Harvest.Web/Controllers/Api/QuoteController.cs
@@ -27,10 +27,10 @@ namespace Harvest.Web.Controllers
 
         // Get info on the project as well as in-progess quote if it exists
         [HttpGet]
-        public async Task<ActionResult> Get(int id)
+        public async Task<ActionResult> Get(int projectId)
         {
-            var project = await _dbContext.Projects.Include(p => p.PrincipalInvestigator).Include(p => p.CreatedBy).SingleAsync(p => p.Id == id);
-            var openQuote = await _dbContext.Quotes.Where(q => q.ProjectId == id && q.ApprovedOn == null).Select(q => QuoteDetail.Deserialize(q.Text)).SingleOrDefaultAsync();
+            var project = await _dbContext.Projects.Include(p => p.PrincipalInvestigator).Include(p => p.CreatedBy).SingleAsync(p => p.Id == projectId);
+            var openQuote = await _dbContext.Quotes.Where(q => q.ProjectId == projectId && q.ApprovedOn == null).Select(q => QuoteDetail.Deserialize(q.Text)).SingleOrDefaultAsync();
 
             var model = new QuoteModel { Project = project, Quote = openQuote };
 
@@ -39,16 +39,16 @@ namespace Harvest.Web.Controllers
 
         // Create a quote for project ID
         [HttpGet]
-        public ActionResult Create(int id)
+        public ActionResult Create(int projectId)
         {
             return View("React");
         }
 
         [HttpPost]
-        public async Task<ActionResult> Save(int id, [FromBody] QuoteDetail quoteDetail)
+        public async Task<ActionResult> Save(int projectId, [FromBody] QuoteDetail quoteDetail)
         {
             // Use existing quote if it exists, otherwise create new one
-            var quote = await _dbContext.Quotes.Where(q => q.ProjectId == id && q.ApprovedOn == null).SingleOrDefaultAsync();
+            var quote = await _dbContext.Quotes.Where(q => q.ProjectId == projectId && q.ApprovedOn == null).SingleOrDefaultAsync();
 
             if (quote == null)
             {
@@ -59,7 +59,7 @@ namespace Harvest.Web.Controllers
                 quote.InitiatedById = currentUser.Id;
                 quote.Status = "New"; // TODO: definte status progression
                 quote.CreatedDate = DateTime.UtcNow;
-                quote.ProjectId = id;
+                quote.ProjectId = projectId;
 
                 await _dbContext.Quotes.AddAsync(quote);
             }

--- a/Harvest.Web/Controllers/Api/RequestController.cs
+++ b/Harvest.Web/Controllers/Api/RequestController.cs
@@ -36,24 +36,24 @@ namespace Harvest.Web.Controllers
 
         // Approve a quote for the project
         [HttpGet]
-        public ActionResult Approve(int id)
+        public ActionResult Approve(int projectId)
         {
             return View("React");
         }
 
         [HttpGet]
-        public ActionResult ChangeAccount(int id)
+        public ActionResult ChangeAccount(int projectId)
         {
             return View("React");
         }
 
         [HttpPost]
-        public async Task<ActionResult> Approve(int id, [FromBody] RequestApprovalModel model)
+        public async Task<ActionResult> Approve(int projectId, [FromBody] RequestApprovalModel model)
         {
-            var project = await _dbContext.Projects.SingleAsync(p => p.Id == id);
+            var project = await _dbContext.Projects.SingleAsync(p => p.Id == projectId);
 
             // get the currently unapproved quote for this project
-            var quote = await _dbContext.Quotes.SingleAsync(q => q.ProjectId == id && q.ApprovedOn == null);
+            var quote = await _dbContext.Quotes.SingleAsync(q => q.ProjectId == projectId && q.ApprovedOn == null);
 
             var currentUser = await _userService.GetCurrentUser();
 
@@ -61,7 +61,7 @@ namespace Harvest.Web.Controllers
             // TODO: add in fiscal officer info??
             foreach (var account in model.Accounts)
             {
-                account.ProjectId = id;
+                account.ProjectId = projectId;
 
                 // Accounts will be auto-approved by quote approver
                 account.ApprovedById = currentUser.Id;
@@ -95,7 +95,7 @@ namespace Harvest.Web.Controllers
 
             // TODO: Maybe inactivate instead?
             // remove any existing accounts that we no longer need
-            _dbContext.RemoveRange(_dbContext.Accounts.Where(x => x.ProjectId == id));
+            _dbContext.RemoveRange(_dbContext.Accounts.Where(x => x.ProjectId == projectId));
 
             await _dbContext.SaveChangesAsync();
 
@@ -103,10 +103,10 @@ namespace Harvest.Web.Controllers
         }
 
         [HttpPost]
-        public async Task<ActionResult> Files(int id, [FromBody] ProjectFilesModel model)
+        public async Task<ActionResult> Files(int projectId, [FromBody] ProjectFilesModel model)
         {
             var currentUser = await _userService.GetCurrentUser();
-            var project = await _dbContext.Projects.Include(a => a.Attachments).Include(p => p.PrincipalInvestigator).Include(p => p.CreatedBy).SingleAsync(p => p.Id == id);
+            var project = await _dbContext.Projects.Include(a => a.Attachments).Include(p => p.PrincipalInvestigator).Include(p => p.CreatedBy).SingleAsync(p => p.Id == projectId);
 
             var newProject = new ProjectAttachment
             {

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -188,7 +188,14 @@ namespace Harvest.Web
             {
                 endpoints.MapControllerRoute(
                     name: "default",
-                    pattern: "{controller=Home}/{action=Index}/{id?}");
+                    pattern: "{controller}/{action}/{id?}",
+                    defaults: new { controller = "Home", action = "Index" },
+                    constraints: new { asset = "(rate|permissions)" }
+                );
+
+                endpoints.MapControllerRoute(
+                    name: "Projects",
+                    pattern: "{controller=Home}/{action=Index}/{projectId?}");
             });
 
             // SPA needs to kick in for all paths during development
@@ -218,7 +225,7 @@ namespace Harvest.Web
 
             var initializer = new DbInitializer(dbContext);
             initializer.Initialize(recreateDb).GetAwaiter().GetResult();
-            
+
         }
     }
 }

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -190,7 +190,7 @@ namespace Harvest.Web
                     name: "default",
                     pattern: "{controller}/{action}/{id?}",
                     defaults: new { controller = "Home", action = "Index" },
-                    constraints: new { asset = "(rate|permissions)" }
+                    constraints: new { controller = "(invoice|rate|permissions)" }
                 );
 
                 endpoints.MapControllerRoute(


### PR DESCRIPTION
other than a few controllers, the default route is now {controller}/{action}/{projectId} and you must take in `int projectId` in those methods.  

It didn't take too many changes to do it, and it'll now make it unambiguous when checking permissions which route param is the project id.

closes #238