### PR TITLE
Ability to do adjustments based on year

### DIFF
--- a/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
@@ -16,6 +16,8 @@ const getDefaultActivity = (id: number) => ({
   id,
   name: "Generic Activity",
   total: 0,
+  year: 0,
+  adjustment: 0,
   workItems: [
     new WorkItemImpl(id, 1, "Labor"),
     new WorkItemImpl(id, 2, "Equipment"),

--- a/Harvest.Web/ClientApp/src/Quotes/ActivitiesContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ActivitiesContainer.tsx
@@ -14,8 +14,10 @@ interface Props {
 export const ActivitiesContainer = (props: Props) => {
   const years = useMemo(() => {
     // difference in years between now and quote date
-    const yearDiff = new Date(props.project.end).getFullYear() - new Date(props.project.start).getFullYear();
-    return 3; // TODO: just for testing
+    return (
+      new Date(props.project.end).getFullYear() -
+      new Date(props.project.start).getFullYear()
+    );
   }, [props.project.start, props.project.end]);
 
   const updateActivity = (activity: Activity) => {

--- a/Harvest.Web/ClientApp/src/Quotes/ActivitiesContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ActivitiesContainer.tsx
@@ -1,16 +1,23 @@
-import React from "react";
+import React, { useMemo } from "react";
 
-import { Activity, QuoteContent, Rate } from "../types";
+import { Activity, Project, QuoteContent, Rate } from "../types";
 
 import { ActivityForm } from "./ActivityForm";
 
 interface Props {
+  project: Project;
   rates: Rate[];
   quote: QuoteContent;
   updateQuote: React.Dispatch<React.SetStateAction<QuoteContent>>;
 }
 
 export const ActivitiesContainer = (props: Props) => {
+  const years = useMemo(() => {
+    // difference in years between now and quote date
+    const yearDiff = new Date(props.project.end).getFullYear() - new Date(props.project.start).getFullYear();
+    return 3; // TODO: just for testing
+  }, [props.project.start, props.project.end]);
+
   const updateActivity = (activity: Activity) => {
     // TODO: can we get away without needing to spread copy?  do we need to totally splice/replace?
     const allActivities = props.quote.activities;
@@ -26,9 +33,11 @@ export const ActivitiesContainer = (props: Props) => {
     props.updateQuote({ ...props.quote, activities: [...allActivities] });
   };
   const deleteActivity = (activity: Activity) => {
-    const allActivities = props.quote.activities.filter((a) => a.id !== activity.id);
+    const allActivities = props.quote.activities.filter(
+      (a) => a.id !== activity.id
+    );
     props.updateQuote({ ...props.quote, activities: [...allActivities] });
-  }
+  };
 
   return (
     <div>
@@ -39,7 +48,7 @@ export const ActivitiesContainer = (props: Props) => {
           updateActivity={(activity: Activity) => updateActivity(activity)}
           deleteActivity={(activity: Activity) => deleteActivity(activity)}
           rates={props.rates}
-          allowAdjustment={true}
+          years={years}
         />
       ))}
     </div>

--- a/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
@@ -87,7 +87,7 @@ export const ActivityForm = (props: Props) => {
                 {props.years !== undefined && props.years > 1 && (
                   <div>
                     <Dropdown isOpen={yearDropdownOpen} toggle={toggle}>
-                      <DropdownToggle caret>
+                      <DropdownToggle color="danger" caret>
                         Year {props.activity.year} ({props.activity.adjustment}
                         %)
                       </DropdownToggle>

--- a/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
@@ -117,7 +117,7 @@ export const ActivityForm = (props: Props) => {
                     </Dropdown>
                   </div>
                 )}
-                {props.years !== undefined && props.years && (
+                {props.years !== undefined && props.years > 1 && (
                   <button className="btn btn-link btn-sm">
                     Duplicate Activity <FontAwesomeIcon icon={faCopy} />
                   </button>

--- a/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
@@ -15,6 +15,7 @@ import { Activity, Rate, RateType, WorkItem, WorkItemImpl } from "../types";
 
 import { WorkItemsForm } from "./WorkItemsForm";
 
+const ANNUAL_ADJUSTMENT_RATE = 3;
 interface Props {
   activity: Activity;
   updateActivity: (activity: Activity) => void;
@@ -64,6 +65,14 @@ export const ActivityForm = (props: Props) => {
     });
   };
 
+  const setYearAndAdjustment = (year: number, adjustment: number) => {
+    props.updateActivity({
+      ...props.activity,
+      adjustment,
+      year,
+    });
+  };
+
   return (
     <div className="card-wrapper mb-4 no-green">
       <div className="card-content">
@@ -76,13 +85,24 @@ export const ActivityForm = (props: Props) => {
 
               <div className="col-md-6 text-right">
                 {props.years !== undefined && props.years > 1 && (
-                  <div className="btn-group">
+                  <div>
                     <Dropdown isOpen={yearDropdownOpen} toggle={toggle}>
-                      <DropdownToggle caret>Year 1</DropdownToggle>
+                      <DropdownToggle caret>
+                        Year {props.activity.year} ({props.activity.adjustment}
+                        %)
+                      </DropdownToggle>
                       <DropdownMenu>
                         {Array.from(Array(props.years)).map((_, i) => (
-                          <DropdownItem key={`year-${i}`}>
-                            Year {i + 1}
+                          <DropdownItem
+                            key={`year-${i}`}
+                            onClick={(_) =>
+                              setYearAndAdjustment(
+                                i + 1,
+                                i * ANNUAL_ADJUSTMENT_RATE
+                              )
+                            }
+                          >
+                            Year {i + 1} ({i * ANNUAL_ADJUSTMENT_RATE}%)
                           </DropdownItem>
                         ))}
                       </DropdownMenu>

--- a/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
@@ -1,10 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 
-import { Input } from "reactstrap";
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownToggle,
+  Input,
+} from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinusCircle } from "@fortawesome/free-solid-svg-icons";
 import { faCopy } from "@fortawesome/free-solid-svg-icons";
-import { faCalendarWeek } from "@fortawesome/free-solid-svg-icons";
 
 import { Activity, Rate, RateType, WorkItem, WorkItemImpl } from "../types";
 
@@ -15,10 +20,14 @@ interface Props {
   updateActivity: (activity: Activity) => void;
   deleteActivity: (activity: Activity) => void;
   rates: Rate[];
-  allowAdjustment?: boolean;
+  years?: number;
 }
 
 export const ActivityForm = (props: Props) => {
+  const [yearDropdownOpen, setYearDropdownOpen] = useState(false);
+
+  const toggle = () => setYearDropdownOpen((prevState) => !prevState);
+
   const updateWorkItems = (workItem: WorkItem) => {
     // TODO: can we get away without needing to spread copy?  do we need to totally splice/replace?
     const allItems = props.activity.workItems;
@@ -66,40 +75,21 @@ export const ActivityForm = (props: Props) => {
               </div>
 
               <div className="col-md-6 text-right">
-                {props.allowAdjustment && (
-                  <div>
-                    <button className="btn btn-link btn-sm">
-                      Adjust Year <FontAwesomeIcon icon={faCalendarWeek} />
-                    </button>
-                    <div className="btn-group">
-                      <button
-                        type="button"
-                        className="btn btn-danger dropdown-toggle"
-                        data-toggle="dropdown"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                      >
-                        Action
-                      </button>
-                      <div className="dropdown-menu">
-                        <a className="dropdown-item" href="#">
-                          Action
-                        </a>
-                        <a className="dropdown-item" href="#">
-                          Another action
-                        </a>
-                        <a className="dropdown-item" href="#">
-                          Something else here
-                        </a>
-                        <div className="dropdown-divider"></div>
-                        <a className="dropdown-item" href="#">
-                          Separated link
-                        </a>
-                      </div>
-                    </div>
+                {props.years !== undefined && props.years > 1 && (
+                  <div className="btn-group">
+                    <Dropdown isOpen={yearDropdownOpen} toggle={toggle}>
+                      <DropdownToggle caret>Year 1</DropdownToggle>
+                      <DropdownMenu>
+                        {Array.from(Array(props.years)).map((_, i) => (
+                          <DropdownItem key={`year-${i}`}>
+                            Year {i + 1}
+                          </DropdownItem>
+                        ))}
+                      </DropdownMenu>
+                    </Dropdown>
                   </div>
                 )}
-                {props.allowAdjustment && (
+                {props.years !== undefined && props.years && (
                   <button className="btn btn-link btn-sm">
                     Duplicate Activity <FontAwesomeIcon icon={faCopy} />
                   </button>

--- a/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
@@ -138,6 +138,7 @@ export const ActivityForm = (props: Props) => {
         </div>
 
         <WorkItemsForm
+          adjustment={props.activity.adjustment}
           category="Labor"
           rates={props.rates.filter((r) => r.type === "Labor")}
           workItems={props.activity.workItems.filter((w) => w.type === "Labor")}
@@ -146,6 +147,7 @@ export const ActivityForm = (props: Props) => {
           deleteWorkItem={deleteWorkItem}
         />
         <WorkItemsForm
+          adjustment={props.activity.adjustment}
           category="Equipment"
           rates={props.rates.filter((r) => r.type === "Equipment")}
           workItems={props.activity.workItems.filter(
@@ -156,6 +158,7 @@ export const ActivityForm = (props: Props) => {
           deleteWorkItem={deleteWorkItem}
         />
         <WorkItemsForm
+          adjustment={props.activity.adjustment}
           category="Other"
           rates={props.rates.filter((r) => r.type === "Other")}
           workItems={props.activity.workItems.filter((w) => w.type === "Other")}

--- a/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ActivityForm.tsx
@@ -37,7 +37,9 @@ export const ActivityForm = (props: Props) => {
     );
     allItems[itemIndex] = {
       ...workItem,
-      total: workItem.rate * workItem.quantity,
+      total:
+        (workItem.rate + (workItem.rate * props.activity.adjustment) / 100.0) *
+        workItem.quantity,
     };
 
     props.updateActivity({ ...props.activity, workItems: allItems });
@@ -70,6 +72,12 @@ export const ActivityForm = (props: Props) => {
       ...props.activity,
       adjustment,
       year,
+      workItems: props.activity.workItems.map((w) => {
+        return {
+          ...w,
+          total: (w.rate + (w.rate * adjustment) / 100.0) * w.quantity,
+        };
+      }),
     });
   };
 

--- a/Harvest.Web/ClientApp/src/Quotes/ProjectDetail.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/ProjectDetail.tsx
@@ -41,6 +41,8 @@ export const ProjectDetail = (props: Props) => {
             new WorkItemImpl(newActivityId, 2, "Equipment"),
             new WorkItemImpl(newActivityId, 3, "Other"),
           ],
+          year: 1, // default new activity to no adjustment
+          adjustment: 0
         },
       ],
     });

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -215,6 +215,7 @@ export const QuoteContainer = () => {
               setEditFields={setEditFields}
             />
             <ActivitiesContainer
+              project={project}
               quote={quote}
               rates={rates}
               updateQuote={setQuote}

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteDisplay.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteDisplay.tsx
@@ -33,7 +33,7 @@ export const QuoteDisplay = (props: Props) => {
             </h4>
           </div>
           <div className="card-content">
-            <WorkItemDisplay workItems={activity.workItems}></WorkItemDisplay>
+            <WorkItemDisplay adjustment={activity.adjustment} workItems={activity.workItems}></WorkItemDisplay>
           </div>
         </div>
       ))}

--- a/Harvest.Web/ClientApp/src/Quotes/WorkItemDisplay.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/WorkItemDisplay.tsx
@@ -3,12 +3,13 @@ import { ActivityRateTypes } from "../constants";
 import { formatCurrency } from "../Util/NumberFormatting";
 
 interface Props {
+  adjustment: number;
   workItems: WorkItem[];
 }
 
 export const WorkItemDisplay = (props: Props) => {
   // TODO: should we break out individual display renderer by labor/equip/other?
-  
+
   return (
     <div>
       {ActivityRateTypes.map((type) => (
@@ -28,7 +29,18 @@ export const WorkItemDisplay = (props: Props) => {
                 <tr key={`item-${workItem.id}`}>
                   <td>{workItem.description}</td>
                   <td>{workItem.quantity}</td>
-                  <td>{workItem.rate}</td>
+                  <td>
+                    {workItem.rate}
+                    {props.adjustment > 0 && (
+                      <span className="primary-color">
+                        {" "}
+                        + $
+                        {formatCurrency(
+                          workItem.rate * (props.adjustment / 100)
+                        )}
+                      </span>
+                    )}
+                  </td>
                   <td>${formatCurrency(workItem.total)}</td>
                 </tr>
               ))}

--- a/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
@@ -18,6 +18,7 @@ import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 
 interface Props {
+  adjustment: number;
   category: RateType;
   rates: Rate[];
   workItems: WorkItem[];
@@ -127,7 +128,14 @@ export const WorkItemsForm = (props: Props) => {
             </InputGroup>
           </Col>
 
-          <Col xs="2">${formatCurrency(workItem.rate || 0)}</Col>
+          <Col xs="2">
+            ${formatCurrency(workItem.rate || 0)}
+            {props.adjustment > 0 && (
+              <span className="primary-color">
+                {" "} + ${formatCurrency(workItem.rate * (props.adjustment / 100))}
+              </span>
+            )}
+          </Col>
 
           <Col xs="1">${formatCurrency(workItem.rate * workItem.quantity)}</Col>
 

--- a/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
@@ -137,7 +137,7 @@ export const WorkItemsForm = (props: Props) => {
             )}
           </Col>
 
-          <Col xs="1">${formatCurrency(workItem.rate * workItem.quantity)}</Col>
+          <Col xs="1">${formatCurrency(workItem.total)}</Col>
 
           <Col xs="1">
             <button

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -212,6 +212,8 @@ export interface Activity {
   total: number;
   id: number;
   name: string;
+  year: number;
+  adjustment: number;
   workItems: WorkItem[];
 }
 

--- a/Harvest.Web/Models/QuoteModel.cs
+++ b/Harvest.Web/Models/QuoteModel.cs
@@ -63,6 +63,8 @@ namespace Harvest.Web.Models
         public int Id { get; set; }
         public string Name { get; set; }
         public double Total { get; set; }
+        public int Year { get; set; }
+        public decimal Adjustment { get; set; }
         public WorkItem[] WorkItems { get; set; }
     }
 


### PR DESCRIPTION
If a request covers >1 year, we show a year selector at the top of each activity, and activities now contain year and adjustment (in percentages, multiples of 3%).  Change this selector adjusts all sub-work items by the given percent.

WorkItems themselves don't change, which is nice because it means we can continue to re-use this component for expense entry.

does the rest of #220 except for duplication and acreage rate