### PR TITLE
default PI to current user when creating new request

### DIFF
--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useHistory, useParams } from "react-router";
 import { Button, FormGroup, Input, Label } from "reactstrap";
 import { ValidationError } from "yup";
@@ -9,6 +9,7 @@ import { SearchPerson } from "./SearchPerson";
 import { Crops } from "./Crops";
 import { requestSchema } from "../schemas";
 import { Project, CropType } from "../types";
+import AppContext from "../Shared/AppContext";
 
 interface RouteParams {
   projectId?: string;
@@ -16,10 +17,13 @@ interface RouteParams {
 
 export const RequestContainer = () => {
   const history = useHistory();
+  const userDetail = useContext(AppContext).user.detail;
+
   const { projectId } = useParams<RouteParams>();
   const [project, setProject] = useState<Project>({
     id: 0,
     cropType: "Row" as CropType,
+    principalInvestigator: userDetail
   } as Project);
   const [inputErrors, setInputErrors] = useState<string[]>([]);
 

--- a/Harvest.Web/ClientApp/src/Shared/AppContext.ts
+++ b/Harvest.Web/ClientApp/src/Shared/AppContext.ts
@@ -1,8 +1,8 @@
 import React from "react";
-import { AppContextShape } from "../types";
+import { AppContextShape, User } from "../types";
 
 const AppContext = React.createContext<AppContextShape>({
-  user: { roles: [] },
+  user: { detail: {} as User, roles: [] },
 });
 
 export default AppContext;

--- a/Harvest.Web/ClientApp/src/Test/mockData.ts
+++ b/Harvest.Web/ClientApp/src/Test/mockData.ts
@@ -1,7 +1,20 @@
 import { AppContextShape, ProjectWithQuote, Rate } from "../types";
 
+const fakeUser = {
+  id: 1,
+  firstName: "Bob",
+  lastName: "Dobalina",
+  email: "bdobalina@ucdavis.edu",
+  iam: "1000037182",
+  kerberos: "bdobalina",
+  name: "Mr Mr Mr Bob Dobalina",
+};
+
 export const fakeAppContext: AppContextShape = {
   user: {
+    detail: {
+      ...fakeUser,
+    },
     roles: ["Admin"],
   },
 };
@@ -16,13 +29,7 @@ export const fakeProject: ProjectWithQuote = {
     requirements: "Grow me some tomatoes",
     name: "Tomato",
     principalInvestigator: {
-      id: 1,
-      firstName: "Scott",
-      lastName: "Kirkland",
-      email: "srkirkland@ucdavis.edu",
-      iam: "1000029584",
-      kerberos: "postit",
-      name: "Scott Kirkland",
+      ...fakeUser,
     },
     location: null,
     locationCode: null,
@@ -35,13 +42,7 @@ export const fakeProject: ProjectWithQuote = {
     currentAccountVersion: 0,
     isActive: false,
     createdBy: {
-      id: 1,
-      firstName: "Scott",
-      lastName: "Kirkland",
-      email: "srkirkland@ucdavis.edu",
-      iam: "1000029584",
-      kerberos: "postit",
-      name: "Scott Kirkland",
+      ...fakeUser,
     },
     accounts: null,
     quotes: null,

--- a/Harvest.Web/ClientApp/src/schemas.ts
+++ b/Harvest.Web/ClientApp/src/schemas.ts
@@ -6,7 +6,7 @@ export const investigatorSchema: SchemaOf<User> = yup
   .object()
   .shape({
     id: yup.number().required(),
-    firstName: yup.string().required(),
+    firstName: yup.string(),
     lastName: yup.string().required(),
     email: yup.string().required(),
     iam: yup.string().required(),

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -52,7 +52,7 @@ export interface Invoice {
 
 export interface User {
   id: number;
-  firstName: string;
+  firstName?: string;
   lastName: string;
   email: string;
   iam: string;

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -287,6 +287,7 @@ export interface ProjectWithInvoice {
 
 export interface AppContextShape {
   user: {
+    detail: User;
     roles: RoleName[];
   };
 }

--- a/Harvest.Web/Extensions/AuthenticationExtensions.cs
+++ b/Harvest.Web/Extensions/AuthenticationExtensions.cs
@@ -20,5 +20,11 @@ namespace Harvest.Web.Extensions
 
             return JsonSerializer.Serialize(roles);
         }
+
+        public static string GetUserDetails(this HttpContext context) {
+            var user = context.User.GetUserInfo();
+
+            return JsonSerializer.Serialize(user, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        }
     }
 }

--- a/Harvest.Web/Extensions/ClaimsExtensions.cs
+++ b/Harvest.Web/Extensions/ClaimsExtensions.cs
@@ -25,7 +25,7 @@ namespace Harvest.Web.Extensions
             var first = claimsPrincipal.Claims.FirstOrDefault(a => a.Type == ClaimTypes.GivenName && !string.IsNullOrWhiteSpace(a.Value));
             return new User
             {
-                FirstName = first?.Value,
+                FirstName = first != null ? first.Value : string.Empty,
                 LastName = claimsPrincipal.FindFirstValue(ClaimTypes.Surname),
                 Email = claimsPrincipal.FindFirstValue(ClaimTypes.Email),
                 Kerberos = claimsPrincipal.FindFirstValue(ClaimTypes.NameIdentifier), //???

--- a/Harvest.Web/Views/Shared/_Layout.cshtml
+++ b/Harvest.Web/Views/Shared/_Layout.cshtml
@@ -115,6 +115,7 @@
 
     <script>
         var Harvest = { user: {} };
+        Harvest.user.detail = @Html.Raw(Context.GetUserDetails());
         Harvest.user.roles = @Html.Raw(await Context.GetUserRoles());
     </script>
 


### PR DESCRIPTION
Added to the layout serialized user context, so now in addition to roles we always know the current user details (could come in handy in other scenarios).  When creating a new request we just take the user details out of the context and make them the default PI.

closes #241