### PR TITLE
cache static spa assets

### DIFF
--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -174,7 +175,18 @@ namespace Harvest.Web
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
-            app.UseSpaStaticFiles();
+            app.UseSpaStaticFiles(new StaticFileOptions()
+            {
+                OnPrepareResponse = (context) =>
+                {
+                    var headers = context.Context.Response.GetTypedHeaders();
+                    headers.CacheControl = new Microsoft.Net.Http.Headers.CacheControlHeaderValue
+                    {
+                        Public = true,
+                        MaxAge = TimeSpan.FromDays(365)
+                    };
+                }
+            });
 
             app.UseRouting();
 

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -179,12 +179,16 @@ namespace Harvest.Web
             {
                 OnPrepareResponse = (context) =>
                 {
-                    var headers = context.Context.Response.GetTypedHeaders();
-                    headers.CacheControl = new Microsoft.Net.Http.Headers.CacheControlHeaderValue
+                    // cache our static assest, i.e. CSS and JS, for a long time
+                    if (context.Context.Request.Path.Value.StartsWith("/static"))
                     {
-                        Public = true,
-                        MaxAge = TimeSpan.FromDays(365)
-                    };
+                        var headers = context.Context.Response.GetTypedHeaders();
+                        headers.CacheControl = new Microsoft.Net.Http.Headers.CacheControlHeaderValue
+                        {
+                            Public = true,
+                            MaxAge = TimeSpan.FromDays(365)
+                        };
+                    }
                 }
             });
 


### PR DESCRIPTION
Only happens in production -- locally we serve from webpack and so the static file handler doesn't apply.

Anything from the /static/ path (specifically anything from the SPA build folder served under the /static/ path) gets cached for a long time.  Since these are hashed it should be fine to do.