### PR TITLE
adds a profile which allows building/running in prod mode locally

### DIFF
--- a/Harvest.Web/Properties/launchSettings.json
+++ b/Harvest.Web/Properties/launchSettings.json
@@ -22,6 +22,14 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    },
+    "Harvest.Web.Production": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Production"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
     }
   }
 }

--- a/Harvest.Web/package.json
+++ b/Harvest.Web/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "start": "dotnet watch run"
+    "start": "dotnet watch run",
+    "production": "dotnet watch run --launch-profile Harvest.Web.Production" 
   },
   "author": "UC Davis",
   "license": "MIT"


### PR DESCRIPTION
useful for debugging.  doesn't affect any default behaviors.  run with `npm run production`

Useful to note that when running in prod your user-secrets don't load, since that's a dev only thing.  