### PR TITLE
Don't fall through to SPA, fallback to ErrorController

### DIFF
--- a/Harvest.Web/Middleware/RewriteError404.cs
+++ b/Harvest.Web/Middleware/RewriteError404.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+
+namespace Harvest.Web.Middleware
+{
+    public class RewriteError404 : DynamicRouteValueTransformer
+    {
+        public override ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
+        {
+            values["controller"] = "Error";
+            values["action"] = "Index";
+            values["statusCode"] = 404;
+            return ValueTask.FromResult(values);
+        }
+    }
+}

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -141,6 +141,7 @@ namespace Harvest.Web
             services.Configure<StorageSettings>(Configuration.GetSection("Storage"));
 
             services.AddSingleton<IFileService, FileService>();
+            services.AddSingleton<RewriteError404>();
             services.AddScoped<IFinancialService, FinancialService>();
             services.AddScoped<IIdentityService, IdentityService>();
             services.AddScoped<IUserService, UserService>();
@@ -183,7 +184,7 @@ namespace Harvest.Web
 
             app.UseMiddleware<LogUserNameMiddleware>();
             app.UseSerilogRequestLogging();
-
+            
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute(
@@ -196,6 +197,9 @@ namespace Harvest.Web
                 endpoints.MapControllerRoute(
                     name: "Projects",
                     pattern: "{controller=Home}/{action=Index}/{projectId?}");
+
+                //similar to MapFallbackToController("Index", "Error"), but adds a statusCode value of 404
+                endpoints.MapDynamicControllerRoute<RewriteError404>("{*path:nonfile}");
             });
 
             // SPA needs to kick in for all paths during development


### PR DESCRIPTION
Falling through to spa results in returning CRA's default index.html. This adds a fallback mapping to Error/Index, adding a statusCode value of 404. I wasn't able to test in a locally published folder in release mode because of some weird problem with React.createContext not being defined.