### PR TITLE
show overlays of existing fields

### DIFF
--- a/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
@@ -5,7 +5,7 @@ import {
   TileLayer,
   Popup,
   GeoJSON,
-  FeatureGroup,
+  FeatureGroup
 } from "react-leaflet";
 
 // TODO: if we need to customize leaflet directly
@@ -14,12 +14,14 @@ import {
 import { EditControl } from "react-leaflet-draw";
 
 import { EditField } from "./EditField";
+import { FieldLayers } from "./FieldLayers";
 import { FieldPopup } from "./FieldPopup";
-import { Field } from "../types";
+import { Field, Project } from "../types";
 
 interface Props {
   crops: string[];
   fields: Field[];
+  project: Project;
   updateFields: (fields: Field[]) => void;
 }
 
@@ -88,6 +90,7 @@ export class FieldContainer extends React.Component<Props, State> {
             attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           />
+          <FieldLayers project={this.props.project}></FieldLayers>
           <FeatureGroup
             ref={(reactFGref) => {
               this._onFeatureGroupReady(reactFGref);
@@ -155,7 +158,7 @@ export class FieldContainer extends React.Component<Props, State> {
     } else {
       this.setState({ editFieldId: undefined });
     }
-  }
+  };
 
   // our render feature group, only used for dynamic drawing
   // once drawing is finished, a field is added and react-leaflet takes over with rendering and control

--- a/Harvest.Web/ClientApp/src/Fields/FieldLayers.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldLayers.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import { LayersControl, GeoJSON, Popup, LayerGroup } from "react-leaflet";
+import { Field, Project } from "../types";
+
+interface Props {
+  project: Project;
+}
+
+export const FieldLayers = (props: Props) => {
+  const [fields, setFields] = useState<Field[]>([]);
+
+  // load fields for active projects
+  useEffect(() => {
+    const cb = async () => {
+      const startDate = new Date(props.project.start);
+      const endDate = new Date(props.project.end);
+
+      const activeFieldResponse = await fetch(
+        `/Field/Active?start=${startDate.toLocaleDateString()}&end=${endDate.toLocaleDateString()}`
+      );
+
+      if (activeFieldResponse.ok) {
+        const activeFields: Field[] = await activeFieldResponse.json();
+        setFields(activeFields);
+      }
+    };
+
+    cb();
+  }, [props.project.end, props.project.start]);
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  return (
+    <LayersControl position="topleft">
+      <LayersControl.Overlay checked name="Active project fields">
+        <LayerGroup>
+          {fields.map((field) => (
+            <GeoJSON
+              key={`field-${field.id}`}
+              data={field.geometry}
+              style={{ color: "red" }}
+            >
+              <Popup>{field.crop}</Popup>
+            </GeoJSON>
+          ))}
+        </LayerGroup>
+      </LayersControl.Overlay>
+    </LayersControl>
+  );
+};

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -207,6 +207,7 @@ export const QuoteContainer = () => {
           <FieldContainer
             crops={cropArray}
             fields={quote.fields}
+            project={project}
             updateFields={(fields) => setQuote({ ...quote, fields })}
           ></FieldContainer>
         </div>


### PR DESCRIPTION
Any field that would be part of a project which overlaps temporally the project you are quoting for should show up so you know what is available.  Can be toggled on/off via leaflet layers control.

Does the bulk of #267 but we might want to make it fancier depending on what would be useful to the field managers.