### PR TITLE
add run.cmd to run the invoice dll

### DIFF
--- a/Harvest.Jobs.Invoice/Harvest.Jobs.Invoice.csproj
+++ b/Harvest.Jobs.Invoice/Harvest.Jobs.Invoice.csproj
@@ -22,6 +22,9 @@
     <None Update="settings.job">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+      <None Update="run.cmd">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Harvest.Jobs.Invoice/run.cmd
+++ b/Harvest.Jobs.Invoice/run.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+dotnet Harvest.Jobs.Invoice.dll


### PR DESCRIPTION
.net 5.0 doesn't create an EXE when publishing anymore, so azure webjobs doesn't find anything to run when we create a release via pipelines.  We could do a self-contained release but then we'd have to target a specific version of windows. 

According to the Kudu docs (https://github.com/projectkudu/kudu/wiki/WebJobs) the webjobs will look for a *.cmd file first, so I made one that just runs the webjob.  Hopefully that'll work.