### PR TITLE
Swe/add history

### DIFF
--- a/Harvest.Core/Extensions/StringExtensions.cs
+++ b/Harvest.Core/Extensions/StringExtensions.cs
@@ -1,12 +1,36 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Harvest.Core.Utilities;
 using Humanizer;
 
 namespace Harvest.Core.Extensions
 {
     public static class StringExtensions
     {
+
+        public static T Deserialize<T>(this string value) => 
+            string.IsNullOrWhiteSpace(value) ? default : JsonSerializer.Deserialize<T>(value, JsonOptions.Standard);
+
+        public static T DeserializeWithGeoJson<T>(this string value) =>
+            string.IsNullOrWhiteSpace(value) ? default : JsonSerializer.Deserialize<T>(value, JsonOptions.Standard.WithGeoJson());
+
+        // shameless copypasta from https://stackoverflow.com/a/5796793
+        public static string SplitCamelCase(this string str)
+        {
+            return Regex.Replace(
+                Regex.Replace(
+                    str,
+                    @"(\P{Ll})(\P{Ll}\p{Ll})",
+                    "$1 $2"
+                ),
+                @"(\p{Ll})(\P{Ll})",
+                "$1 $2"
+            );
+        }
+
         public static string SafeHumanizeTitle(this string value)
         {
             if (string.IsNullOrWhiteSpace(value))

--- a/Harvest.Core/Models/History/AccountHistoryModel.cs
+++ b/Harvest.Core/Models/History/AccountHistoryModel.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Harvest.Core.Domain;
+
+namespace Harvest.Core.Models.History
+{
+    public class AccountHistoryModel
+    {
+        public AccountHistoryModel() { }
+
+        public AccountHistoryModel(Account account)
+        {
+            Id = account.Id;
+            ProjectId = account.ProjectId;
+            Number = account.Number;
+            Name = account.Name;
+            AccountManagerName = account.AccountManagerName;
+            AccountManagerEmail = account.AccountManagerEmail;
+            Percentage = account.Percentage;
+            ApprovedById = account.ApprovedById;
+            ApprovedOn = account.ApprovedOn;
+            ApprovedBy = UserHistoryModel.CreateFrom(account.ApprovedBy);
+        }
+
+        public int Id { get; set; }
+        public int ProjectId { get; set; }
+        public string Number { get; set; }
+        public string Name { get; set; }
+        public string AccountManagerName { get; set; }
+        public string AccountManagerEmail { get; set; }
+        public decimal Percentage { get; set; }
+        public int? ApprovedById { get; set; }
+        public DateTime? ApprovedOn { get; set; }
+        public UserHistoryModel ApprovedBy { get; set; }
+    }
+}

--- a/Harvest.Core/Models/History/FieldHistoryModel.cs
+++ b/Harvest.Core/Models/History/FieldHistoryModel.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Harvest.Core.Domain;
+using NetTopologySuite.Geometries;
+
+namespace Harvest.Core.Models.History
+{
+    public class FieldHistoryModel
+    {
+        public FieldHistoryModel() {}
+
+        public FieldHistoryModel(Field field)
+        {
+            Id = field.Id;
+            ProjectId = field.ProjectId;
+            Crop = field.Crop;
+            Details = field.Details;
+            Location = field.Location;
+            IsActive = field.IsActive;
+        }
+
+        public int Id { get; set; }
+        public int ProjectId { get; set; }
+        public string Crop { get; set; }
+        public string Details { get; set; }
+        public Polygon Location { get; set; }
+        public bool IsActive { get; set; }
+    }
+}

--- a/Harvest.Core/Models/History/FileHistoryModel.cs
+++ b/Harvest.Core/Models/History/FileHistoryModel.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Harvest.Core.Domain;
+
+namespace Harvest.Core.Models.History
+{
+    public class FileHistoryModel
+    {
+        public FileHistoryModel() { }
+
+        public FileHistoryModel(AttachmentBase attachment)
+        {
+            Id = attachment.Id;
+            FileName = attachment.FileName;
+            ContentType = attachment.ContentType;
+            FileSize = attachment.FileSize;
+            CreatedById = attachment.CreatedById;
+            CreatedBy = UserHistoryModel.CreateFrom(attachment.CreatedBy);
+            CreatedOn = attachment.CreatedOn;
+            Identifier = attachment.Identifier;
+        }
+
+        public int Id { get; set; }
+        public string FileName { get; set; }
+        public string ContentType { get; set; }
+        public int FileSize { get; set; }
+        public int CreatedById { get; set; }
+        public UserHistoryModel CreatedBy { get; set; }
+        public DateTime CreatedOn { get; set; }
+        public string Identifier { get; set; }
+    }
+}

--- a/Harvest.Core/Models/History/ProjectHistoryModel.cs
+++ b/Harvest.Core/Models/History/ProjectHistoryModel.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Harvest.Core.Domain;
+using Harvest.Core.Extensions;
+using Harvest.Core.Utilities;
+
+namespace Harvest.Core.Models.History
+{
+    public class ProjectHistoryModel
+    {
+        public ProjectHistoryModel() { }
+
+        public ProjectHistoryModel(Project project)
+        {
+            Id = project.Id;
+            Start = project.Start;
+            End = project.End;
+            Crop = project.Crop;
+            CropType = project.CropType;
+            Requirements = project.Requirements;
+            Acres = project.Acres;
+            AcreageRateId = project.AcreageRateId;
+            AcreageRate = RateHistoryModel.CreateFrom(project.AcreageRate);
+            Name = project.Name;
+            PrincipalInvestigatorId = project.PrincipalInvestigatorId;
+            PrincipalInvestigator = UserHistoryModel.CreateFrom(project.PrincipalInvestigator);
+            QuoteId = project.QuoteId;
+            Quote = project.Quote?.Text.Deserialize<QuoteDetail>();
+            OriginalProjectId = project.OriginalProjectId;
+            QuoteTotal = project.QuoteTotal;
+            ChargedTotal = project.ChargedTotal;
+            CreatedById = project.CreatedById;
+            CreatedOn = project.CreatedOn;
+            Status = project.Status;
+
+            CreatedById = project.CreatedById;
+            CreatedOn = project.CreatedOn;
+            Status = project.Status;
+            CurrentAccountVersion = project.CurrentAccountVersion;
+            IsApproved = project.IsApproved;
+            IsActive = project.IsActive;
+            CreatedBy = UserHistoryModel.CreateFrom(project.CreatedBy);
+            Accounts = project.Accounts?.Select(a => new AccountHistoryModel(a)).ToList();
+            Fields = project.Fields?.Select(f => new FieldHistoryModel(f)).ToList();
+        }
+
+        public int Id { get; set; }
+        public DateTime Start { get; set; }
+        public DateTime End { get; set; }
+        public string Crop { get; set; }
+        public string CropType { get; set; }
+        public string Requirements { get; set; }
+        public double Acres { get; set; }
+        public int? AcreageRateId { get; set; }
+        public RateHistoryModel AcreageRate { get; set; }
+        public string Name { get; set; }
+        public int PrincipalInvestigatorId { get; set; }
+        public UserHistoryModel PrincipalInvestigator { get; set; }
+        public int? QuoteId { get; set; }
+        public QuoteDetail Quote { get; set; }
+        public int? OriginalProjectId { get; set; }
+        public decimal QuoteTotal { get; set; }
+        public decimal ChargedTotal { get; set; }
+        public int CreatedById { get; set; }
+        public DateTime CreatedOn { get; set; }
+        public string Status { get; set; }
+        public int CurrentAccountVersion { get; set; }
+        public bool IsApproved { get; set; } = false;
+        public bool IsActive { get; set; }
+        public UserHistoryModel CreatedBy { get; set; }
+        public List<AccountHistoryModel> Accounts { get; set; }
+        public List<FieldHistoryModel> Fields { get; set; }
+    }
+}

--- a/Harvest.Core/Models/History/ProjectTotalHistoryModel.cs
+++ b/Harvest.Core/Models/History/ProjectTotalHistoryModel.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Harvest.Core.Domain;
+
+namespace Harvest.Core.Models.History
+{
+    public class ProjectTotalHistoryModel
+    {
+        public ProjectTotalHistoryModel() { }
+
+        public ProjectTotalHistoryModel(Project project)
+        {
+            Id = project.Id;
+            ChargedTotal = project.ChargedTotal;
+        }
+
+        public int Id { get; set; }
+        public decimal ChargedTotal { get; set; }
+    }
+}

--- a/Harvest.Core/Models/History/RateHistoryModel.cs
+++ b/Harvest.Core/Models/History/RateHistoryModel.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Harvest.Core.Domain;
+
+namespace Harvest.Core.Models.History
+{
+    public class RateHistoryModel
+    {
+        public static RateHistoryModel CreateFrom(Rate rate)
+        {
+            if (rate == null)
+            {
+                return null;
+            }
+
+            return new RateHistoryModel
+            {
+                Id = rate.Id,
+                IsActive = rate.IsActive,
+                Type = rate.Type,
+                Description = rate.Description,
+                Unit = rate.Unit,
+                BillingUnit = rate.BillingUnit,
+                Account = rate.Account,
+                Price = rate.Price,
+                EffectiveOn = rate.EffectiveOn,
+                CreatedById = rate.CreatedById,
+                UpdatedById = rate.UpdatedById,
+                CreatedOn = rate.CreatedOn,
+                UpdatedOn = rate.UpdatedOn
+            };
+        }
+
+        public int Id { get; set; }
+        public bool IsActive { get; set; } = true;
+        public string Type { get; set; }
+        public string Description { get; set; }
+        public string Unit { get; set; }
+        public string BillingUnit { get; set; }
+        public string Account { get; set; }
+        public decimal Price { get; set; }
+        public DateTime? EffectiveOn { get; set; }
+        public int CreatedById { get; set; }
+        public int UpdatedById { get; set; }
+        public DateTime CreatedOn { get; set; }
+        public DateTime UpdatedOn { get; set; }
+
+    }
+}

--- a/Harvest.Core/Models/History/TicketHistoryModel.cs
+++ b/Harvest.Core/Models/History/TicketHistoryModel.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Harvest.Core.Domain;
+
+namespace Harvest.Core.Models.History
+{
+    public class TicketHistoryModel
+    {
+        public TicketHistoryModel() { }
+
+        public TicketHistoryModel(Ticket ticket)
+        {
+            Id = ticket.Id;
+            ProjectId = ticket.ProjectId;
+            InvoiceId = ticket.InvoiceId;
+            CreatedById = ticket.CreatedById;
+            CreatedOn = ticket.CreatedOn;
+            UpdatedById = ticket.UpdatedById;
+            UpdatedOn = ticket.UpdatedOn;
+            Name = ticket.Name;
+            Requirements = ticket.Requirements;
+            DueDate = ticket.DueDate;
+            WorkNotes = ticket.WorkNotes;
+            Status = ticket.Status;
+            Completed = ticket.Completed;
+        }
+
+        public int Id { get; set; }
+        public int ProjectId { get; set; }
+        public int? InvoiceId { get; set; }
+        public int CreatedById { get; set; }
+        public DateTime CreatedOn { get; set; }
+        public int? UpdatedById { get; set; }
+        public DateTime? UpdatedOn { get; set; }
+        public string Name { get; set; }
+        public string Requirements { get; set; }
+        public DateTime? DueDate { get; set; }
+        public string WorkNotes { get; set; }
+        public string Status { get; set; }
+        public bool Completed { get; set; }
+
+    }
+}

--- a/Harvest.Core/Models/History/TicketMessageHistoryModel.cs
+++ b/Harvest.Core/Models/History/TicketMessageHistoryModel.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Harvest.Core.Domain;
+
+namespace Harvest.Core.Models.History
+{
+    public class TicketMessageHistoryModel
+    {
+        public TicketMessageHistoryModel() { }
+
+        public TicketMessageHistoryModel(TicketMessage message)
+        {
+            Id = message.Id;
+            Message = message.Message;
+            CreatedById = message.CreatedById;
+            CreatedOn = message.CreatedOn;
+            TicketId = message.TicketId;
+        }
+
+        public int Id { get; set; }
+        public string Message { get; set; }
+        public int CreatedById { get; set; }
+        public DateTime CreatedOn { get; set; }
+        public int TicketId { get; set; }
+    }
+}

--- a/Harvest.Core/Models/History/UserHistoryModel.cs
+++ b/Harvest.Core/Models/History/UserHistoryModel.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Harvest.Core.Domain;
+
+namespace Harvest.Core.Models.History
+{
+    public class UserHistoryModel
+    {
+        public UserHistoryModel() { }
+
+        public static UserHistoryModel CreateFrom(User user)
+        {
+            if (user == null)
+            {
+                return null;
+            }
+
+            return new UserHistoryModel
+            {
+                Id = user.Id,
+                FirstName = user.FirstName,
+                LastName = user.LastName,
+                Email = user.Email,
+                Iam = user.Iam,
+                Kerberos = user.Kerberos
+            };
+        }
+
+        public int Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+        public string Iam { get; set; }
+        public string Kerberos { get; set; }
+    }
+}

--- a/Harvest.Core/Models/QuoteModel.cs
+++ b/Harvest.Core/Models/QuoteModel.cs
@@ -5,7 +5,7 @@ using Harvest.Core.Domain;
 using Harvest.Core.Utilities;
 using NetTopologySuite.Geometries;
 
-namespace Harvest.Web.Models
+namespace Harvest.Core.Models
 {
     public class QuoteModel
     {

--- a/Harvest.Core/Services/InvoiceService.cs
+++ b/Harvest.Core/Services/InvoiceService.cs
@@ -70,6 +70,7 @@ namespace Harvest.Core.Services
             {
                 //Ok, so the project has ended, we should probably create the last invoice, and close it out. Setting the project to completed.
                 project.Status = Project.Statuses.Completed;
+                await _historyService.AddProjectHistory(project, $"{nameof(InvoiceService)}.{nameof(CreateInvoice)}", "Project Completed", new InvoiceModel(newInvoice));
             }
 
             //Acreage fees are ignored for manually created invoices
@@ -90,7 +91,7 @@ namespace Harvest.Core.Services
 
             _dbContext.Invoices.Add(newInvoice);
 
-            await _historyService.AddProjectHistory(project, nameof(CreateInvoice), "Invoice created", new InvoiceModel(newInvoice));
+            await _historyService.AddProjectHistory(project, $"{nameof(InvoiceService)}.{nameof(CreateInvoice)}", "Invoice created", new InvoiceModel(newInvoice));
 
             await _dbContext.SaveChangesAsync(); //Do one save outside of this?
             return Result.Value(newInvoice.Id);
@@ -130,7 +131,7 @@ namespace Harvest.Core.Services
             };
 
             await _dbContext.Expenses.AddAsync(expense);
-            await _historyService.AddProjectHistory(project, nameof(CreateMonthlyAcreageExpense), "Monthly acreage expense created", new ExpenseModel(expense));
+            await _historyService.AddProjectHistory(project, $"{nameof(InvoiceService)}.{nameof(CreateMonthlyAcreageExpense)}", "Monthly acreage expense created", new ExpenseModel(expense));
             await _dbContext.SaveChangesAsync();
 
         }

--- a/Harvest.Core/Services/InvoiceService.cs
+++ b/Harvest.Core/Services/InvoiceService.cs
@@ -90,10 +90,10 @@ namespace Harvest.Core.Services
 
             _dbContext.Invoices.Add(newInvoice);
 
-            await _historyService.AddProjectHistory(project.Id, $"{nameof(InvoiceService)}.{nameof(CreateInvoice)}", "Invoice created", new InvoiceModel(newInvoice));
+            await _historyService.InvoiceCreated(project.Id, newInvoice);
             if (project.Status == Project.Statuses.Completed)
             {
-                await _historyService.AddProjectHistory(project.Id, $"{nameof(InvoiceService)}.{nameof(CreateInvoice)}", "Project Completed", new InvoiceModel(newInvoice));
+                await _historyService.ProjectCompleted(project.Id, project);
             }
 
             await _dbContext.SaveChangesAsync(); //Do one save outside of this?
@@ -134,7 +134,7 @@ namespace Harvest.Core.Services
             };
 
             await _dbContext.Expenses.AddAsync(expense);
-            await _historyService.AddProjectHistory(project.Id, $"{nameof(InvoiceService)}.{nameof(CreateMonthlyAcreageExpense)}", "Monthly acreage expense created", new ExpenseModel(expense));
+            await _historyService.AcreageExpenseCreated(project.Id, expense);
             await _dbContext.SaveChangesAsync();
 
         }

--- a/Harvest.Core/Services/InvoiceService.cs
+++ b/Harvest.Core/Services/InvoiceService.cs
@@ -70,7 +70,6 @@ namespace Harvest.Core.Services
             {
                 //Ok, so the project has ended, we should probably create the last invoice, and close it out. Setting the project to completed.
                 project.Status = Project.Statuses.Completed;
-                await _historyService.AddProjectHistory(project, $"{nameof(InvoiceService)}.{nameof(CreateInvoice)}", "Project Completed", new InvoiceModel(newInvoice));
             }
 
             //Acreage fees are ignored for manually created invoices
@@ -91,7 +90,11 @@ namespace Harvest.Core.Services
 
             _dbContext.Invoices.Add(newInvoice);
 
-            await _historyService.AddProjectHistory(project, $"{nameof(InvoiceService)}.{nameof(CreateInvoice)}", "Invoice created", new InvoiceModel(newInvoice));
+            await _historyService.AddProjectHistory(project.Id, $"{nameof(InvoiceService)}.{nameof(CreateInvoice)}", "Invoice created", new InvoiceModel(newInvoice));
+            if (project.Status == Project.Statuses.Completed)
+            {
+                await _historyService.AddProjectHistory(project.Id, $"{nameof(InvoiceService)}.{nameof(CreateInvoice)}", "Project Completed", new InvoiceModel(newInvoice));
+            }
 
             await _dbContext.SaveChangesAsync(); //Do one save outside of this?
             return Result.Value(newInvoice.Id);
@@ -131,7 +134,7 @@ namespace Harvest.Core.Services
             };
 
             await _dbContext.Expenses.AddAsync(expense);
-            await _historyService.AddProjectHistory(project, $"{nameof(InvoiceService)}.{nameof(CreateMonthlyAcreageExpense)}", "Monthly acreage expense created", new ExpenseModel(expense));
+            await _historyService.AddProjectHistory(project.Id, $"{nameof(InvoiceService)}.{nameof(CreateMonthlyAcreageExpense)}", "Monthly acreage expense created", new ExpenseModel(expense));
             await _dbContext.SaveChangesAsync();
 
         }

--- a/Harvest.Core/Services/ProjectHistoryService.cs
+++ b/Harvest.Core/Services/ProjectHistoryService.cs
@@ -11,7 +11,13 @@ namespace Harvest.Core.Services
 {
     public interface IProjectHistoryService
     {
-        Task<ProjectHistory> AddProjectHistory(Project project, string action, string description, object detailsToSerialize, User user = null);
+
+        /// <summary>
+        /// Creates a <see cref="ProjectHistory"/> record for a given <paramref name="projectId"/>
+        /// </summary>
+        /// <remarks>If <paramref name="detailsToSerialize"/> contains domain entities, consider calling this before those entities get attached
+        /// to a <see cref="AppDbContext"/> to avoid serializing more of the object graph.</remarks>
+        Task<ProjectHistory> AddProjectHistory(int projectId, string action, string description, object detailsToSerialize, User user = null);
     }
 
     public class ProjectHistoryService : IProjectHistoryService
@@ -27,7 +33,12 @@ namespace Harvest.Core.Services
             _jsonOptions = jsonOptions;
         }
 
-        public async Task<ProjectHistory> AddProjectHistory(Project project, string action, string description, object detailsToSerialize, User user = null)
+        /// <summary>
+        /// Creates a <see cref="ProjectHistory"/> record for a given <paramref name="projectId"/>
+        /// </summary>
+        /// <remarks>If <paramref name="detailsToSerialize"/> contains domain entities, consider calling this before those entities get attached
+        /// to a <see cref="AppDbContext"/> to avoid serializing more of the object graph.</remarks>
+        public async Task<ProjectHistory> AddProjectHistory(int projectId, string action, string description, object detailsToSerialize, User user = null)
         {
             user ??= await _userService.GetCurrentUser();
 
@@ -35,7 +46,7 @@ namespace Harvest.Core.Services
 
             var projectHistory = new ProjectHistory
             {
-                Project = project,
+                ProjectId = projectId,
                 Action = action,
                 Description = user != null ? $"{description} by {user.Name}" : description,
                 Details = details,

--- a/Harvest.Core/Services/ProjectHistoryService.cs
+++ b/Harvest.Core/Services/ProjectHistoryService.cs
@@ -1,23 +1,42 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security.Principal;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Harvest.Core.Data;
 using Harvest.Core.Domain;
+using Harvest.Core.Extensions;
+using Harvest.Core.Models;
+using Harvest.Core.Models.History;
+using Harvest.Core.Models.InvoiceModels;
+using Harvest.Core.Utilities;
 
 namespace Harvest.Core.Services
 {
     public interface IProjectHistoryService
     {
-
-        /// <summary>
-        /// Creates a <see cref="ProjectHistory"/> record for a given <paramref name="projectId"/>
-        /// </summary>
-        /// <remarks>If <paramref name="detailsToSerialize"/> contains domain entities, consider calling this before those entities get attached
-        /// to a <see cref="AppDbContext"/> to avoid serializing more of the object graph.</remarks>
-        Task<ProjectHistory> AddProjectHistory(int projectId, string action, string description, object detailsToSerialize, User user = null);
+        Task<ProjectHistory> AccountChanged(int projectId, IEnumerable<Account> accounts);
+        Task<ProjectHistory> AcreageExpenseCreated(int projectId, Expense expense);
+        Task<ProjectHistory> ExpensesCreated(int projectId, IEnumerable<Expense> expenses);
+        Task<ProjectHistory> ExpenseDeleted(int projectId, Expense expense);
+        Task<ProjectHistory> InvoiceCancelled(int projectId, Invoice invoice);
+        Task<ProjectHistory> InvoiceCompleted(int projectId, Invoice invoice);
+        Task<ProjectHistory> InvoiceCreated(int projectId, Invoice invoice);
+        Task<ProjectHistory> MoveMoneyRequested(int projectId, Invoice invoice);
+        Task<ProjectHistory> ProjectCompleted(int projectId, Project project);
+        Task<ProjectHistory> ProjectFilesAttached(int projectId, IEnumerable<ProjectAttachment> attachments);
+        Task<ProjectHistory> ProjectTotalRefreshed(int projectId, Project project);
+        Task<ProjectHistory> QuoteApproved(int projectId, IEnumerable<Account> accounts);
+        Task<ProjectHistory> QuoteSaved(int projectId, Quote quote);
+        Task<ProjectHistory> QuoteSubmitted(int projectId, Quote quote);
+        Task<ProjectHistory> RequestCreated(int projectId, Project project);
+        Task<ProjectHistory> TicketCreated(int projectId, Ticket ticket);
+        Task<ProjectHistory> TicketFilesAttached(int projectId, IEnumerable<TicketAttachment> attachments);
+        Task<ProjectHistory> TicketNotesUpdated(int projectId, Ticket ticket);
+        Task<ProjectHistory> TicketReplyCreated(int projectId, TicketMessage message);
     }
 
     public class ProjectHistoryService : IProjectHistoryService
@@ -26,36 +45,68 @@ namespace Harvest.Core.Services
         private readonly AppDbContext _dbContext;
         private readonly JsonSerializerOptions _jsonOptions;
 
-        public ProjectHistoryService(IUserService userService, AppDbContext dbContext, JsonSerializerOptions jsonOptions)
+        public ProjectHistoryService(IUserService userService, AppDbContext dbContext)
         {
             _userService = userService;
             _dbContext = dbContext;
-            _jsonOptions = jsonOptions;
+            _jsonOptions = JsonOptions.Standard.WithGeoJson();
         }
 
-        /// <summary>
-        /// Creates a <see cref="ProjectHistory"/> record for a given <paramref name="projectId"/>
-        /// </summary>
-        /// <remarks>If <paramref name="detailsToSerialize"/> contains domain entities, consider calling this before those entities get attached
-        /// to a <see cref="AppDbContext"/> to avoid serializing more of the object graph.</remarks>
-        public async Task<ProjectHistory> AddProjectHistory(int projectId, string action, string description, object detailsToSerialize, User user = null)
+        public Task<ProjectHistory> AccountChanged(int projectId, IEnumerable<Account> accounts) =>
+            MakeHistory(projectId, nameof(AccountChanged), accounts.Select(a => new AccountHistoryModel(a)));
+        public Task<ProjectHistory> AcreageExpenseCreated(int projectId, Expense expense) =>
+            MakeHistory(projectId, nameof(AcreageExpenseCreated), new ExpenseModel(expense));
+        public Task<ProjectHistory> ExpensesCreated(int projectId, IEnumerable<Expense> expenses) =>
+            MakeHistory(projectId, nameof(ExpensesCreated), expenses.Select(e => new ExpenseModel(e)));
+        public Task<ProjectHistory> ExpenseDeleted(int projectId, Expense expense) =>
+            MakeHistory(projectId, nameof(ExpenseDeleted), new ExpenseModel(expense));
+        public Task<ProjectHistory> InvoiceCancelled(int projectId, Invoice invoice) =>
+            MakeHistory(projectId, nameof(InvoiceCancelled), new InvoiceModel(invoice));
+        public Task<ProjectHistory> InvoiceCompleted(int projectId, Invoice invoice) =>
+            MakeHistory(projectId, nameof(InvoiceCompleted), new InvoiceModel(invoice));
+        public Task<ProjectHistory> InvoiceCreated(int projectId, Invoice invoice) => 
+            MakeHistory(projectId, nameof(InvoiceCreated), new InvoiceModel(invoice));
+        public Task<ProjectHistory> MoveMoneyRequested(int projectId, Invoice invoice) =>
+            MakeHistory(projectId, nameof(MoveMoneyRequested), new InvoiceModel(invoice));
+        public Task<ProjectHistory> ProjectCompleted(int projectId, Project project) => 
+            MakeHistory(projectId, nameof(ProjectCompleted), new ProjectHistoryModel(project));
+        public Task<ProjectHistory> ProjectFilesAttached(int projectId, IEnumerable<ProjectAttachment> attachments) =>
+            MakeHistory(projectId, nameof(ProjectFilesAttached), attachments.Select(a => new FileHistoryModel(a)));
+        public Task<ProjectHistory> ProjectTotalRefreshed(int projectId, Project project) =>
+            MakeHistory(projectId, nameof(ProjectTotalRefreshed), new ProjectTotalHistoryModel(project));
+        public Task<ProjectHistory> QuoteSaved(int projectId, Quote quote) =>
+            MakeHistory(projectId, nameof(QuoteSaved), quote.Text); // quote.Text is a preserialized QuoteDetail
+        public Task<ProjectHistory> QuoteSubmitted(int projectId, Quote quote) =>
+            MakeHistory(projectId, nameof(QuoteSubmitted), quote.Text); // quote.Text is a preserialized QuoteDetail
+        public Task<ProjectHistory> QuoteApproved(int projectId, IEnumerable<Account> accounts) =>
+            MakeHistory(projectId, nameof(QuoteApproved), accounts.Select(a => new AccountHistoryModel(a)));
+        public Task<ProjectHistory> RequestCreated(int projectId, Project project) =>
+            MakeHistory(projectId, nameof(RequestCreated), new ProjectHistoryModel(project));
+        public Task<ProjectHistory> TicketCreated(int projectId, Ticket ticket) =>
+            MakeHistory(projectId, nameof(TicketCreated), new TicketHistoryModel(ticket));
+        public Task<ProjectHistory> TicketFilesAttached(int projectId, IEnumerable<TicketAttachment> attachments) =>
+            MakeHistory(projectId, nameof(TicketFilesAttached), attachments.Select(a => new FileHistoryModel(a)));
+        public Task<ProjectHistory> TicketNotesUpdated(int projectId, Ticket ticket) =>
+            MakeHistory(projectId, nameof(TicketNotesUpdated), new TicketHistoryModel(ticket));
+        public Task<ProjectHistory> TicketReplyCreated(int projectId, TicketMessage message) =>
+            MakeHistory(projectId, nameof(TicketReplyCreated), new TicketMessageHistoryModel(message));
+
+
+        private Task<ProjectHistory> MakeHistory(int projectId, string action, object detailsModel) =>
+            MakeHistory(projectId, action, JsonSerializer.Serialize(detailsModel, _jsonOptions));
+
+        private async Task<ProjectHistory> MakeHistory(int projectId, string action, string detailsSerialized)
         {
-            user ??= await _userService.GetCurrentUser();
-
-            var details = detailsToSerialize == null ? "" : JsonSerializer.Serialize(detailsToSerialize, _jsonOptions);
-
             var projectHistory = new ProjectHistory
             {
-                ProjectId = projectId,
                 Action = action,
-                Description = user != null ? $"{description} by {user.Name}" : description,
-                Details = details,
+                Description = action.SplitCamelCase(),
+                Details = detailsSerialized,
+                ProjectId = projectId,
                 ActionDate = DateTime.UtcNow,
-                Actor = user,
+                Actor = await _userService.GetCurrentUser(),
             };
-
-            _dbContext.ProjectHistory.Add(projectHistory);
-
+            _dbContext.Add(projectHistory);
             return projectHistory;
         }
     }

--- a/Harvest.Core/Services/SlothService.cs
+++ b/Harvest.Core/Services/SlothService.cs
@@ -220,7 +220,7 @@ namespace Harvest.Core.Services
                 //Update running total
                 invoice.Project.ChargedTotal += invoice.Total;
 
-                await _historyService.AddProjectHistory(invoice.Project, nameof(MoveMoney), "Sloth money movement requested", new InvoiceModel(invoice));
+                await _historyService.AddProjectHistory(invoice.Project.Id, $"{nameof(SlothService)}.{nameof(MoveMoney)}", "Sloth money movement requested", new InvoiceModel(invoice));
                 await _dbContext.SaveChangesAsync();
 
 
@@ -284,14 +284,14 @@ namespace Harvest.Core.Services
                         updatedCount++;
 
                         invoice.Status = Invoice.Statuses.Completed;
-                        await _historyService.AddProjectHistory(invoice.Project, nameof(ProcessTransferUpdates), "Invoice completed", new InvoiceModel(invoice));
+                        await _historyService.AddProjectHistory(invoice.Project.Id, $"{nameof(SlothService)}.{nameof(ProcessTransferUpdates)}", "Invoice completed", new InvoiceModel(invoice));
                         await _dbContext.SaveChangesAsync();
                     }
                     if (slothResponse.Status == "Cancelled")
                     {
 
                         Log.Information("Invoice {transferId} was cancelled. What do we do?!!!!", invoice.Id);
-                        await _historyService.AddProjectHistory(invoice.Project, nameof(ProcessTransferUpdates), "Invoice cancelled", new InvoiceModel(invoice));
+                        await _historyService.AddProjectHistory(invoice.Project.Id, $"{nameof(SlothService)}.{nameof(ProcessTransferUpdates)}", "Invoice cancelled", new InvoiceModel(invoice));
                         rolledBackCount++;
                         //TODO: Write to the notes field? Trigger off an email?
                     }

--- a/Harvest.Core/Services/SlothService.cs
+++ b/Harvest.Core/Services/SlothService.cs
@@ -220,7 +220,7 @@ namespace Harvest.Core.Services
                 //Update running total
                 invoice.Project.ChargedTotal += invoice.Total;
 
-                await _historyService.AddProjectHistory(invoice.Project.Id, $"{nameof(SlothService)}.{nameof(MoveMoney)}", "Sloth money movement requested", new InvoiceModel(invoice));
+                await _historyService.MoveMoneyRequested(invoice.ProjectId, invoice);
                 await _dbContext.SaveChangesAsync();
 
 
@@ -284,14 +284,14 @@ namespace Harvest.Core.Services
                         updatedCount++;
 
                         invoice.Status = Invoice.Statuses.Completed;
-                        await _historyService.AddProjectHistory(invoice.Project.Id, $"{nameof(SlothService)}.{nameof(ProcessTransferUpdates)}", "Invoice completed", new InvoiceModel(invoice));
+                        await _historyService.InvoiceCompleted(invoice.ProjectId, invoice);
                         await _dbContext.SaveChangesAsync();
                     }
                     if (slothResponse.Status == "Cancelled")
                     {
 
                         Log.Information("Invoice {transferId} was cancelled. What do we do?!!!!", invoice.Id);
-                        await _historyService.AddProjectHistory(invoice.Project.Id, $"{nameof(SlothService)}.{nameof(ProcessTransferUpdates)}", "Invoice cancelled", new InvoiceModel(invoice));
+                        await _historyService.InvoiceCancelled(invoice.ProjectId, invoice);
                         rolledBackCount++;
                         //TODO: Write to the notes field? Trigger off an email?
                     }

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -18,11 +18,13 @@ namespace Harvest.Web.Controllers
     {
         private readonly AppDbContext _dbContext;
         private readonly IUserService _userService;
+        private readonly IProjectHistoryService _historyService;
 
-        public ExpenseController(AppDbContext dbContext, IUserService userService)
+        public ExpenseController(AppDbContext dbContext, IUserService userService, IProjectHistoryService historyService)
         {
             this._dbContext = dbContext;
             this._userService = userService;
+            this._historyService = historyService;
         }
 
         public ActionResult Entry()
@@ -52,6 +54,8 @@ namespace Harvest.Web.Controllers
                 expense.Account = allRates.Single(a => a.Id == expense.RateId).Account;
             }
 
+            await _historyService.AddProjectHistory(projectId, $"{nameof(ExpenseController)}.{nameof(Create)}", "Expenses Created", expenses);
+
             _dbContext.Expenses.AddRange(expenses);
 
             await _dbContext.SaveChangesAsync();
@@ -67,6 +71,8 @@ namespace Harvest.Web.Controllers
             if (expense == null) {
                 return NotFound();
             }
+
+            await _historyService.AddProjectHistory(expense.ProjectId, $"{nameof(ExpenseController)}.{nameof(Delete)}", "Expense Deleted", expense);
 
             _dbContext.Expenses.Remove(expense);
             await _dbContext.SaveChangesAsync();

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -54,9 +54,9 @@ namespace Harvest.Web.Controllers
                 expense.Account = allRates.Single(a => a.Id == expense.RateId).Account;
             }
 
-            await _historyService.AddProjectHistory(projectId, $"{nameof(ExpenseController)}.{nameof(Create)}", "Expenses Created", expenses);
-
             _dbContext.Expenses.AddRange(expenses);
+
+            await _historyService.ExpensesCreated(projectId, expenses);
 
             await _dbContext.SaveChangesAsync();
 
@@ -72,9 +72,8 @@ namespace Harvest.Web.Controllers
                 return NotFound();
             }
 
-            await _historyService.AddProjectHistory(expense.ProjectId, $"{nameof(ExpenseController)}.{nameof(Delete)}", "Expense Deleted", expense);
-
             _dbContext.Expenses.Remove(expense);
+            await _historyService.ExpenseDeleted(expense.ProjectId, expense);
             await _dbContext.SaveChangesAsync();
 
             return Ok(null);

--- a/Harvest.Web/Controllers/Api/QuoteController.cs
+++ b/Harvest.Web/Controllers/Api/QuoteController.cs
@@ -76,10 +76,12 @@ namespace Harvest.Web.Controllers
 
                 var project = await _dbContext.Projects.SingleAsync(p => p.Id == projectId);
                 project.Status = Project.Statuses.PendingApproval;
+                await _historyService.QuoteSubmitted(projectId, quote);
             }
-
-            await _historyService.AddProjectHistory(projectId, $"{nameof(QuoteController)}.{nameof(Save)}",
-                $"Quote {(submit ? "Submitted" : "Saved")}", quoteDetail);
+            else
+            {
+                await _historyService.QuoteSaved(projectId, quote);
+            }
 
             await _dbContext.SaveChangesAsync();
 

--- a/Harvest.Web/Controllers/Api/QuoteController.cs
+++ b/Harvest.Web/Controllers/Api/QuoteController.cs
@@ -18,11 +18,13 @@ namespace Harvest.Web.Controllers
     {
         private readonly AppDbContext _dbContext;
         private readonly IUserService _userService;
+        private readonly IProjectHistoryService _historyService;
 
-        public QuoteController(AppDbContext dbContext, IUserService userService)
+        public QuoteController(AppDbContext dbContext, IUserService userService, IProjectHistoryService historyService)
         {
             this._dbContext = dbContext;
             this._userService = userService;
+            this._historyService = historyService;
         }
 
         // Get info on the project as well as in-progess quote if it exists
@@ -75,6 +77,9 @@ namespace Harvest.Web.Controllers
                 var project = await _dbContext.Projects.SingleAsync(p => p.Id == projectId);
                 project.Status = Project.Statuses.PendingApproval;
             }
+
+            await _historyService.AddProjectHistory(projectId, $"{nameof(QuoteController)}.{nameof(Save)}",
+                $"Quote {(submit ? "Submitted" : "Saved")}", quoteDetail);
 
             await _dbContext.SaveChangesAsync();
 

--- a/Harvest.Web/Controllers/Api/RequestController.cs
+++ b/Harvest.Web/Controllers/Api/RequestController.cs
@@ -106,8 +106,8 @@ namespace Harvest.Web.Controllers
                 project.Fields.Add(field);
             }
 
-            await _historyService.AddProjectHistory(project.Id, $"{nameof(RequestController)}.{nameof(Approve)}", "Quote Approved", model);
-
+            await _historyService.QuoteApproved(project.Id, model.Accounts);
+ 
             await _dbContext.SaveChangesAsync();
 
             return Ok(project);
@@ -145,7 +145,7 @@ namespace Harvest.Web.Controllers
             // remove any existing accounts that we no longer need
             _dbContext.RemoveRange(_dbContext.Accounts.Where(x => x.ProjectId == projectId));
 
-            await _historyService.AddProjectHistory(project.Id, $"{nameof(RequestController)}.{nameof(ChangeAccount)}", "Account Changed", model);
+            await _historyService.AccountChanged(project.Id, model.Accounts);
 
             await _dbContext.SaveChangesAsync();
 
@@ -174,11 +174,10 @@ namespace Harvest.Web.Controllers
                 projectAttachmentsToCreate.Add(newProject);
             }
 
-            await _historyService.AddProjectHistory(project.Id, $"{nameof(RequestController)}.{nameof(Files)}", "Files(s) Attached", model);
-
             project.Attachments.AddRange(projectAttachmentsToCreate);
 
             _dbContext.Projects.Update(project);
+            await _historyService.ProjectFilesAttached(project.Id, model.Attachments);
             await _dbContext.SaveChangesAsync();
 
             return Ok(null);
@@ -243,9 +242,8 @@ namespace Harvest.Web.Controllers
             // TODO: when is name determined? Currently by quote creator but can it be changed?
             newProject.Name = piName + "-" + project.Start.ToString("MMMMyyyy");
 
-            await _historyService.AddProjectHistory(project.Id, $"{nameof(RequestController)}.{nameof(Create)}", $"Request Created ({newProject.Status})", newProject);
-
             await _dbContext.Projects.AddAsync(newProject);
+            await _historyService.RequestCreated(project.Id, newProject);
             await _dbContext.SaveChangesAsync();
 
             return Ok(newProject);

--- a/Harvest.Web/Controllers/Api/RequestController.cs
+++ b/Harvest.Web/Controllers/Api/RequestController.cs
@@ -19,11 +19,13 @@ namespace Harvest.Web.Controllers
     {
         private readonly AppDbContext _dbContext;
         private readonly IUserService _userService;
+        private readonly IProjectHistoryService _historyService;
 
-        public RequestController(AppDbContext dbContext, IUserService userService)
+        public RequestController(AppDbContext dbContext, IUserService userService, IProjectHistoryService historyService)
         {
             this._dbContext = dbContext;
             this._userService = userService;
+            this._historyService = historyService;
         }
 
 
@@ -104,6 +106,8 @@ namespace Harvest.Web.Controllers
                 project.Fields.Add(field);
             }
 
+            await _historyService.AddProjectHistory(project.Id, $"{nameof(RequestController)}.{nameof(Approve)}", "Quote Approved", model);
+
             await _dbContext.SaveChangesAsync();
 
             return Ok(project);
@@ -141,6 +145,8 @@ namespace Harvest.Web.Controllers
             // remove any existing accounts that we no longer need
             _dbContext.RemoveRange(_dbContext.Accounts.Where(x => x.ProjectId == projectId));
 
+            await _historyService.AddProjectHistory(project.Id, $"{nameof(RequestController)}.{nameof(ChangeAccount)}", "Account Changed", model);
+
             await _dbContext.SaveChangesAsync();
 
             return Ok(project);
@@ -167,6 +173,8 @@ namespace Harvest.Web.Controllers
 
                 projectAttachmentsToCreate.Add(newProject);
             }
+
+            await _historyService.AddProjectHistory(project.Id, $"{nameof(RequestController)}.{nameof(Files)}", "Files(s) Attached", model);
 
             project.Attachments.AddRange(projectAttachmentsToCreate);
 
@@ -234,6 +242,8 @@ namespace Harvest.Web.Controllers
 
             // TODO: when is name determined? Currently by quote creator but can it be changed?
             newProject.Name = piName + "-" + project.Start.ToString("MMMMyyyy");
+
+            await _historyService.AddProjectHistory(project.Id, $"{nameof(RequestController)}.{nameof(Create)}", $"Request Created ({newProject.Status})", newProject);
 
             await _dbContext.Projects.AddAsync(newProject);
             await _dbContext.SaveChangesAsync();

--- a/Harvest.Web/Controllers/ProjectController.cs
+++ b/Harvest.Web/Controllers/ProjectController.cs
@@ -17,11 +17,13 @@ namespace Harvest.Web.Controllers
     {
         private readonly AppDbContext _dbContext;
         private readonly IUserService _userService;
+        private readonly IProjectHistoryService _historyService;
 
-        public ProjectController(AppDbContext dbContext, IUserService userService)
+        public ProjectController(AppDbContext dbContext, IUserService userService, IProjectHistoryService historyService)
         {
             this._dbContext = dbContext;
             this._userService = userService;
+            this._historyService = historyService;
         }
         public ActionResult Index()
         {
@@ -114,6 +116,10 @@ namespace Harvest.Web.Controllers
             if (project.ChargedTotal != invoiceTotal)
             {
                 project.ChargedTotal = invoiceTotal;
+
+                await _historyService.AddProjectHistory(project.Id, $"{nameof(ProjectController)}.{nameof(RefreshTotal)}", "Project Total Refreshed",
+                    $"Project total updated from {originalTotal} to {project.ChargedTotal}");
+
                 await _dbContext.SaveChangesAsync();
                 return Content($"Project total updated from {originalTotal} to {project.ChargedTotal}");
             }

--- a/Harvest.Web/Controllers/ProjectController.cs
+++ b/Harvest.Web/Controllers/ProjectController.cs
@@ -117,15 +117,12 @@ namespace Harvest.Web.Controllers
             {
                 project.ChargedTotal = invoiceTotal;
 
-                await _historyService.AddProjectHistory(project.Id, $"{nameof(ProjectController)}.{nameof(RefreshTotal)}", "Project Total Refreshed",
-                    $"Project total updated from {originalTotal} to {project.ChargedTotal}");
-
+                await _historyService.ProjectTotalRefreshed(project.Id, project);
                 await _dbContext.SaveChangesAsync();
                 return Content($"Project total updated from {originalTotal} to {project.ChargedTotal}");
             }
 
             return Content("Project already up to date.");
-
         }
     }
 }


### PR DESCRIPTION
Addresses most of #201

It was hard to decide what to include in each history model. They are kind of a mishmash of near-complete mirrors of domain entities, small models with just enough data to be relevant to a given action, and already-existing models. 

A lot of the serialized history has pk Id values of 0, since the dbContext has not been saved at the time of serialization. Should I place the history generation after dbContext saves and then perform a second save just for the history?