### PR TITLE
order projects by name

### DIFF
--- a/Harvest.Web/Controllers/ProjectController.cs
+++ b/Harvest.Web/Controllers/ProjectController.cs
@@ -55,6 +55,7 @@ namespace Harvest.Web.Controllers
             return Ok(await _dbContext.Projects
                 .Include(p => p.PrincipalInvestigator)
                 .Where(p => p.IsActive)
+                .OrderBy(p => p.Name)
                 .ToArrayAsync());
         }
 


### PR DESCRIPTION
isn't exactly the last word in ordering but it helps a lot.  Really we need to figure out how they want to refer to the projects before we manually create a format for them.

closes #352