### PR TITLE
Allow using useInputValidator and ValidationProvider in same component

### DIFF
--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -49,9 +49,7 @@ function App() {
         path="/invoice/details/:invoiceId"
         component={InvoiceDetailContainer}
       />
-      <ConditionalRoute roles={["FieldManager", "Supervisor"]} path="/quote/create/:projectId" >
-        <ValidationProvider><QuoteContainer /></ValidationProvider>
-      </ConditionalRoute>
+      <ConditionalRoute roles={["FieldManager", "Supervisor"]} path="/quote/create/:projectId" component={QuoteContainer} />
       <ConditionalRoute exact roles={["FieldManager", "Supervisor"]} path="/project" >
         <ProjectListContainer projectSource="/Project/Active" />
       </ConditionalRoute>

--- a/Harvest.Web/ClientApp/src/FormValidation/UseInputValidator.tsx
+++ b/Harvest.Web/ClientApp/src/FormValidation/UseInputValidator.tsx
@@ -2,16 +2,15 @@
 import { useDebounceCallback } from '@react-hook/debounce'
 import { AnyObjectSchema, ValidationError } from "yup";
 
-import { ValidationContext } from "./ValidationProvider";
+import { ValidationContext, ValidationContextState, useValidationContext } from "./ValidationProvider";
 import { notEmptyOrFalsey } from "../Util/ValueChecks";
 
 export function useInputValidator<T>(schema: AnyObjectSchema) {
   type TKey = keyof T;
 
-  const context = useContext(ValidationContext);
-  if (context === null) {
-    throw new Error("Form does not appear to be wrapped in a <ValidationProvider>");
-  }
+  const defaultContext = useValidationContext();
+  const providerContext = useContext(ValidationContext);
+  const context = providerContext || defaultContext;
 
   const { formErrorCount, setFormErrorCount, formIsTouched, setFormIsTouched, formIsDirty,
     setFormIsDirty, resetContext, contextIsReset } = context;
@@ -112,7 +111,8 @@ export function useInputValidator<T>(schema: AnyObjectSchema) {
     formIsDirty,
     fieldIsDirty,
     resetContext,
-    resetField
+    resetField,
+    context
   }
 }
 

--- a/Harvest.Web/ClientApp/src/FormValidation/UseInputValidator.tsx
+++ b/Harvest.Web/ClientApp/src/FormValidation/UseInputValidator.tsx
@@ -2,15 +2,13 @@
 import { useDebounceCallback } from '@react-hook/debounce'
 import { AnyObjectSchema, ValidationError } from "yup";
 
-import { ValidationContext, ValidationContextState, useValidationContext } from "./ValidationProvider";
+import { ValidationContext, ValidationContextState, useOrCreateValidationContext } from "./ValidationProvider";
 import { notEmptyOrFalsey } from "../Util/ValueChecks";
 
 export function useInputValidator<T>(schema: AnyObjectSchema) {
   type TKey = keyof T;
 
-  const defaultContext = useValidationContext();
-  const providerContext = useContext(ValidationContext);
-  const context = providerContext || defaultContext;
+  const context = useOrCreateValidationContext(useContext(ValidationContext));
 
   const { formErrorCount, setFormErrorCount, formIsTouched, setFormIsTouched, formIsDirty,
     setFormIsDirty, resetContext, contextIsReset } = context;

--- a/Harvest.Web/ClientApp/src/FormValidation/ValidationProvider.tsx
+++ b/Harvest.Web/ClientApp/src/FormValidation/ValidationProvider.tsx
@@ -14,8 +14,7 @@ export interface ValidationContextState {
 
 export const ValidationContext = React.createContext<ValidationContextState | null>(null);
 
-export const useValidationContext = () => {
-
+export const useOrCreateValidationContext = (context?: ValidationContextState | null) => {
   const [formErrorCount, setFormErrorCount] = useState(0);
   const [formIsTouched, setFormIsTouched] = useState(false);
   const [formIsDirty, setFormIsDirty] = useState(false);
@@ -33,7 +32,12 @@ export const useValidationContext = () => {
     }
   }, [formErrorCount, formIsTouched, formIsDirty, contextIsReset, setcontextIsReset]);
 
-  const context: ValidationContextState = {
+  if (context) {
+    // wishing this early return could be earlier, but RULES of HOOKS
+    return context;
+  }
+
+  const newContext: ValidationContextState = {
     formErrorCount,
     setFormErrorCount,
     formIsTouched,
@@ -44,7 +48,7 @@ export const useValidationContext = () => {
     contextIsReset,
   }
 
-  return context;
+  return newContext;
 }
 
 export interface ValidationProviderProps {
@@ -52,8 +56,8 @@ export interface ValidationProviderProps {
 }
 
 export const ValidationProvider: React.FC<ValidationProviderProps> = (props) => {
-  const defaultContext = useValidationContext();
+  const context = useOrCreateValidationContext(props.context);
 
-  return <ValidationContext.Provider value={props.context || defaultContext}>{props.children}</ValidationContext.Provider>;
+  return <ValidationContext.Provider value={context}>{props.children}</ValidationContext.Provider>;
 }
 

--- a/Harvest.Web/ClientApp/src/FormValidation/ValidationProvider.tsx
+++ b/Harvest.Web/ClientApp/src/FormValidation/ValidationProvider.tsx
@@ -14,7 +14,7 @@ export interface ValidationContextState {
 
 export const ValidationContext = React.createContext<ValidationContextState | null>(null);
 
-export const ValidationProvider: React.FC = ({ children }) => {
+export const useValidationContext = () => {
 
   const [formErrorCount, setFormErrorCount] = useState(0);
   const [formIsTouched, setFormIsTouched] = useState(false);
@@ -33,7 +33,7 @@ export const ValidationProvider: React.FC = ({ children }) => {
     }
   }, [formErrorCount, formIsTouched, formIsDirty, contextIsReset, setcontextIsReset]);
 
-  const contextState: ValidationContextState = {
+  const context: ValidationContextState = {
     formErrorCount,
     setFormErrorCount,
     formIsTouched,
@@ -44,6 +44,16 @@ export const ValidationProvider: React.FC = ({ children }) => {
     contextIsReset,
   }
 
-  return <ValidationContext.Provider value={contextState}>{children}</ValidationContext.Provider>;
+  return context;
+}
+
+export interface ValidationProviderProps {
+  context?: ValidationContextState
+}
+
+export const ValidationProvider: React.FC<ValidationProviderProps> = (props) => {
+  const defaultContext = useValidationContext();
+
+  return <ValidationContext.Provider value={props.context || defaultContext}>{props.children}</ValidationContext.Provider>;
 }
 

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -18,7 +18,7 @@ import { QuoteTotals } from "./QuoteTotals";
 import {
   usePromiseNotification,
 } from "../Util/Notifications";
-import { useInputValidator } from "../FormValidation";
+import { useInputValidator, ValidationProvider } from "../FormValidation";
 import { quoteContentSchema } from "../schemas";
 import { checkValidity } from "../Util/ValidationHelpers";
 
@@ -32,7 +32,7 @@ export const QuoteContainer = () => {
   const [project, setProject] = useState<Project>();
   const [inputErrors, setInputErrors] = useState<string[]>([]);
 
-  const { formErrorCount } = useInputValidator<QuoteContent>(quoteContentSchema);
+  const { formErrorCount, context } = useInputValidator<QuoteContent>(quoteContentSchema);
 
   // TODO: set with in-progress quote details if they exist
   // For now, we just always initialize an empty quote
@@ -245,54 +245,56 @@ export const QuoteContainer = () => {
   }
 
   return (
-    <div className="card-wrapper">
-      <ProjectHeader
-        project={project}
-        title={"Field Request #" + (project?.id || "")}
-      ></ProjectHeader>
-      <div className="card-green-bg">
-        <div className="card-content">
-          <div className="quote-details">
-            <h2>Quote Details</h2>
-            <hr />
-            <ProjectDetail
-              rates={rates}
-              quote={quote}
-              updateQuote={setQuote}
-              setEditFields={setEditFields}
-            />
-            <ActivitiesContainer
-              quote={quote}
-              rates={rates}
-              updateQuote={setQuote}
-            />
-          </div>
-          <QuoteTotals quote={quote}></QuoteTotals>
-          <div className="row justify-content-center">
-            <ul>
-              {inputErrors.map((error, i) => {
-                return (
-                  <li className="text-danger" key={`error-${i}`}>
-                    {error}
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-          <div className="row justify-content-center">
-            <button className="btn btn-link mt-4" onClick={() => save(false)} disabled={notification.pending || formErrorCount > 0}>
-              Save Quote
+    <ValidationProvider context={context}>
+      <div className="card-wrapper">
+        <ProjectHeader
+          project={project}
+          title={"Field Request #" + (project?.id || "")}
+        ></ProjectHeader>
+        <div className="card-green-bg">
+          <div className="card-content">
+            <div className="quote-details">
+              <h2>Quote Details</h2>
+              <hr />
+              <ProjectDetail
+                rates={rates}
+                quote={quote}
+                updateQuote={setQuote}
+                setEditFields={setEditFields}
+              />
+              <ActivitiesContainer
+                quote={quote}
+                rates={rates}
+                updateQuote={setQuote}
+              />
+            </div>
+            <QuoteTotals quote={quote}></QuoteTotals>
+            <div className="row justify-content-center">
+              <ul>
+                {inputErrors.map((error, i) => {
+                  return (
+                    <li className="text-danger" key={`error-${i}`}>
+                      {error}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+            <div className="row justify-content-center">
+              <button className="btn btn-link mt-4" onClick={() => save(false)} disabled={notification.pending || formErrorCount > 0}>
+                Save Quote
             </button>
-            <button className="btn btn-primary mt-4" onClick={() => save(true)} disabled={notification.pending || !isValid() || formErrorCount > 0}>
-              Submit Quote
+              <button className="btn btn-primary mt-4" onClick={() => save(true)} disabled={notification.pending || !isValid() || formErrorCount > 0}>
+                Submit Quote
             </button>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div>Debug: {JSON.stringify(quote)}</div>
-      <div>Debug Rates: {JSON.stringify(rates)}</div>
-      <div>Debug: Total:{quote.grandTotal}</div>
-    </div>
+        <div>Debug: {JSON.stringify(quote)}</div>
+        <div>Debug Rates: {JSON.stringify(rates)}</div>
+        <div>Debug: Total:{quote.grandTotal}</div>
+      </div>
+    </ValidationProvider>
   );
 };


### PR DESCRIPTION
ValidationProvider can now be used in the same component as useInputValidator by passing the returned context to ValidationProvider.

Since useInputValidator will now create its own default context, it no longer throws a message about needing a `<ValidationProvider />`

If you don't use a ValidationProvider, the form-level props returned will only be applicable to the local component.
