### PR TITLE
Ensure mounted before setting state after fetch/async ops

### DIFF
--- a/Harvest.Web/ClientApp/src/Expenses/ProjectSelection.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ProjectSelection.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { FormGroup, Input } from "reactstrap";
 
 import { Project } from "../types";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface Props {
   selectedProject: (projectId: number) => void;
@@ -11,6 +12,7 @@ interface Props {
 export const ProjectSelection = (props: Props) => {
   const [projects, setProjects] = useState<Project[]>();
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     // get list of projects
     const cb = async () => {
@@ -19,12 +21,12 @@ export const ProjectSelection = (props: Props) => {
       if (response.ok) {
         const projects = await response.json();
 
-        setProjects(projects);
+        getIsMounted() && setProjects(projects);
       }
     };
 
     cb();
-  }, []);
+  }, [getIsMounted]);
 
   if (projects === undefined) {
     return <div>Loading...</div>;

--- a/Harvest.Web/ClientApp/src/Fields/FieldLayers.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldLayers.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { LayersControl, GeoJSON, Popup, LayerGroup } from "react-leaflet";
 import { Field, Project } from "../types";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface Props {
   project: Project;
@@ -8,6 +9,7 @@ interface Props {
 
 export const FieldLayers = (props: Props) => {
   const [fields, setFields] = useState<Field[]>([]);
+  const getIsMounted = useIsMounted();
 
   // load fields for active projects
   useEffect(() => {
@@ -21,12 +23,12 @@ export const FieldLayers = (props: Props) => {
 
       if (activeFieldResponse.ok) {
         const activeFields: Field[] = await activeFieldResponse.json();
-        setFields(activeFields);
+        getIsMounted() && setFields(activeFields);
       }
     };
 
     cb();
-  }, [props.project.end, props.project.start]);
+  }, [props.project.end, props.project.start, getIsMounted]);
 
   if (fields.length === 0) {
     return null;

--- a/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
@@ -3,20 +3,24 @@ import { Link } from "react-router-dom";
 
 import { StatusToActionRequired } from "../Util/MessageHelpers";
 import { Project } from "../types";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 export const FieldManagerHome = () => {
   const [projects, setProjects] = useState<Project[]>();
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     // get info on projects requiring approval
     const getProjects = async () => {
       const response = await fetch("/project/RequiringManagerAttention");
-      const projects: Project[] = await response.json();
-      setProjects(projects);
+      if (getIsMounted()) {
+        const projects: Project[] = await response.json();
+        getIsMounted() && setProjects(projects);
+      }
     };
 
     getProjects();
-  }, []);
+  }, [getIsMounted]);
 
   return (
     <>

--- a/Harvest.Web/ClientApp/src/Home/PIHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/PIHome.tsx
@@ -3,19 +3,23 @@ import { Link } from "react-router-dom";
 
 import { Project } from "../types";
 import { StatusToActionRequired } from "../Util/MessageHelpers";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 export const PIHome = () => {
   const [projects, setProjects] = useState<Project[]>([]);
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const getProjectsWaitingForMe = async () => {
       const response = await fetch("/project/RequiringPIAttention");
-      const projects: Project[] = await response.json();
-      setProjects(projects);
+      if (getIsMounted()) {
+        const projects: Project[] = await response.json();
+        getIsMounted() && setProjects(projects);
+      }
     };
 
     getProjectsWaitingForMe();
-  }, []);
+  }, [getIsMounted]);
 
   return (
     <>

--- a/Harvest.Web/ClientApp/src/Home/SupervisorHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/SupervisorHome.tsx
@@ -2,20 +2,24 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Project } from "../types";
 import { StatusToActionRequired } from "../Util/MessageHelpers";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 export const SupervisorHome = () => {
   const [projects, setProjects] = useState<Project[]>();
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     // get info on projects requiring approval
     const getProjects = async () => {
       const response = await fetch("/project/RequiringManagerAttention");
-      const projects: Project[] = await response.json();
-      setProjects(projects);
+      if (getIsMounted()) {
+        const projects: Project[] = await response.json();
+        getIsMounted() && setProjects(projects);
+      }
     };
 
     getProjects();
-  }, []);
+  }, [getIsMounted]);
 
   return (
     <>

--- a/Harvest.Web/ClientApp/src/Home/WorkerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/WorkerHome.tsx
@@ -2,19 +2,23 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { Project } from "../types";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 export const WorkerHome = () => {
   const [projects, setProjects] = useState<Project[]>([]);
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const getProjectsWithRecentExpenses = async () => {
       const response = await fetch("/expense/GetRecentExpensedProjects");
-      const projects: Project[] = await response.json();
-      setProjects(projects);
+      if (getIsMounted()) {
+        const projects: Project[] = await response.json();
+        getIsMounted() && setProjects(projects);
+      }
     };
 
     getProjectsWithRecentExpenses();
-  }, []);
+  }, [getIsMounted]);
 
   return (
     <>

--- a/Harvest.Web/ClientApp/src/Invoices/InvoiceDetailContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/InvoiceDetailContainer.tsx
@@ -6,6 +6,7 @@ import { ProjectWithInvoice } from "../types";
 import { InvoicePDF } from "../Pdf/InvoicePDF";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { InvoiceDisplay } from "./InvoiceDisplay";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDownload } from "@fortawesome/free-solid-svg-icons";
@@ -21,6 +22,7 @@ export const InvoiceDetailContainer = () => {
     setProjectAndInvoice,
   ] = useState<ProjectWithInvoice>();
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
       const invoiceResponse = await fetch(`/Invoice/Get/${invoiceId}`);
@@ -28,12 +30,12 @@ export const InvoiceDetailContainer = () => {
       if (invoiceResponse.ok) {
         const projectWithInvoice: ProjectWithInvoice = await invoiceResponse.json();
 
-        setProjectAndInvoice(projectWithInvoice);
+        getIsMounted() && setProjectAndInvoice(projectWithInvoice);
       }
     };
 
     cb();
-  }, [invoiceId]);
+  }, [invoiceId, getIsMounted]);
 
   if (projectAndInvoice === undefined) {
     return <div>Loading ...</div>;

--- a/Harvest.Web/ClientApp/src/Invoices/InvoiceListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/InvoiceListContainer.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 
 import { Invoice } from "../types";
 import { InvoiceTable } from "./InvoiceTable";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface RouteParams {
   projectId?: string;
@@ -12,20 +13,21 @@ export const InvoiceListContainer = () => {
   const { projectId } = useParams<RouteParams>();
   const [invoices, setInvoices] = useState<Invoice[]>([]);
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
       const response = await fetch(`/Project/Invoices/${projectId}`);
 
       if (response.ok) {
-        setInvoices(await response.json());
+        getIsMounted() && setInvoices(await response.json());
       }
     };
 
     if (projectId) {
       cb();
     }
-  }, [projectId]);
+  }, [projectId, getIsMounted]);
 
   if (invoices.length === 0) {
     return <div>No invoices found</div>;

--- a/Harvest.Web/ClientApp/src/Invoices/RecentInvoicesContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/RecentInvoicesContainer.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { Invoice } from "../types";
 import { InvoiceTable } from "./InvoiceTable";
 import { ShowFor } from "../Shared/ShowFor";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface Props {
   projectId?: string;
@@ -13,18 +14,19 @@ interface Props {
 export const RecentInvoicesContainer = (props: Props) => {
   const [invoices, setInvoices] = useState<Invoice[]>([]);
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
       // TODO: only fetch first 5 instead of chopping off client-side
       const response = await fetch(`/Project/Invoices/${props.projectId}`);
 
       if (response.ok) {
-        setInvoices(await response.json());
+        getIsMounted() && setInvoices(await response.json());
       }
     };
 
     cb();
-  }, [props.projectId]);
+  }, [props.projectId, getIsMounted]);
 
   return (
     <ShowFor roles={["FieldManager", "Supervisor", "PI"]}>

--- a/Harvest.Web/ClientApp/src/Projects/ProjectFields.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectFields.tsx
@@ -4,6 +4,7 @@ import { GeoJSON, MapContainer, TileLayer, Popup } from "react-leaflet";
 import { Project } from "../types";
 import { getBoundingBox } from "../Util/Geography";
 import { LatLngBoundsExpression } from "leaflet";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface ProjectField {
   id: number;
@@ -18,6 +19,7 @@ interface ProjectField {
 export const ProjectFields = () => {
   const [fields, setFields] = useState<ProjectField[]>([]);
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const getFields = async () => {
       const response = await fetch("/Project/GetFields");
@@ -25,12 +27,12 @@ export const ProjectFields = () => {
       if (response.ok) {
         const result = await response.json();
         console.log(result);
-        setFields(result);
+        getIsMounted() && setFields(result);
       }
     };
 
     getFields();
-  }, []);
+  }, [getIsMounted]);
 
   const bounds: LatLngBoundsExpression = useMemo(() => {
     const bounds = getBoundingBox(fields.map((f) => f.location));
@@ -60,8 +62,18 @@ export const ProjectFields = () => {
               <div className="tooltip-description">
                 <p>Crops: {field.crop}</p>
                 <p>{field.details}</p>
-                <p>Start Date: {new Intl.DateTimeFormat('en-US').format(new Date(field.project.start))}</p>
-                <p>End Date: {new Intl.DateTimeFormat('en-US').format(new Date(field.project.end))}</p>
+                <p>
+                  Start Date:{" "}
+                  {new Intl.DateTimeFormat("en-US").format(
+                    new Date(field.project.start)
+                  )}
+                </p>
+                <p>
+                  End Date:{" "}
+                  {new Intl.DateTimeFormat("en-US").format(
+                    new Date(field.project.end)
+                  )}
+                </p>
                 <Link to={`/project/details/${field.projectId}`}>
                   Project Details
                 </Link>

--- a/Harvest.Web/ClientApp/src/Projects/ProjectListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectListContainer.tsx
@@ -3,12 +3,13 @@ import { Link } from "react-router-dom";
 
 import { Project } from "../types";
 import { ProjectTable } from "./ProjectTable";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 
 interface Props {
-  projectSource: string
+  projectSource: string;
 }
 
 const getListTitle = (projectSource: string) => {
@@ -18,23 +19,24 @@ const getListTitle = (projectSource: string) => {
     default:
       return "Projects";
   }
-}
+};
 
 export const ProjectListContainer = (props: Props) => {
   const [projects, setProjects] = useState<Project[]>([]);
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
       const response = await fetch(props.projectSource);
 
       if (response.ok) {
-        setProjects(await response.json());
+        getIsMounted() && setProjects(await response.json());
       }
     };
 
     cb();
-  }, [props.projectSource]);
+  }, [props.projectSource, getIsMounted]);
 
   return (
     <div>

--- a/Harvest.Web/ClientApp/src/Projects/ProjectUnbilledButton.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectUnbilledButton.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { formatCurrency } from "../Util/NumberFormatting";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface Props {
   projectId: number;
@@ -9,6 +10,7 @@ interface Props {
 export const ProjectUnbilledButton = (props: Props) => {
   const [total, setTotal] = useState<number>();
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
@@ -17,15 +19,19 @@ export const ProjectUnbilledButton = (props: Props) => {
       );
 
       if (response.ok) {
-        setTotal(Number.parseFloat(await response.text()));
+        getIsMounted() && setTotal(Number.parseFloat(await response.text()));
       }
     };
 
     cb();
-  }, [props.projectId]);
+  }, [props.projectId, getIsMounted]);
 
   if (total === 0) {
-    return <button className="btn btn-light" disabled>Unbilled Expenses - $0.00</button>;
+    return (
+      <button className="btn btn-light" disabled>
+        Unbilled Expenses - $0.00
+      </button>
+    );
   }
 
   return (

--- a/Harvest.Web/ClientApp/src/Requests/AccountChangeContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/AccountChangeContainer.tsx
@@ -5,6 +5,7 @@ import { Project, ProjectAccount } from "../types";
 import { AccountsInput } from "./AccountsInput";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { usePromiseNotification } from "../Util/Notifications";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface RouteParams {
   projectId?: string;
@@ -19,6 +20,7 @@ export const AccountChangeContainer = () => {
 
   const [notification, setNotification] = usePromiseNotification();
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
       const response = await fetch(`/Project/Get/${projectId}`);
@@ -26,12 +28,12 @@ export const AccountChangeContainer = () => {
       if (response.ok) {
         const proj: Project = await response.json();
 
-        setProject(proj);
+        getIsMounted() && setProject(proj);
       }
     };
 
     cb();
-  }, [projectId]);
+  }, [projectId, getIsMounted]);
 
   if (project === undefined) {
     return <div>Loading ...</div>;

--- a/Harvest.Web/ClientApp/src/Requests/AccountsInput.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/AccountsInput.tsx
@@ -9,6 +9,7 @@ import { ProjectAccount } from "../types";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinusCircle } from "@fortawesome/free-solid-svg-icons";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface Props {
   accounts: ProjectAccount[];
@@ -27,6 +28,7 @@ export const AccountsInput = (props: Props) => {
 
   const { accounts, setAccounts } = props;
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     let total = 0;
     for (let i = 0; i < accounts.length; i++) {
@@ -43,11 +45,11 @@ export const AccountsInput = (props: Props) => {
 
     if (response.ok) {
       if (response.status === 204) {
-        setSearchResultAccounts([]); // no content
+        getIsMounted() && setSearchResultAccounts([]); // no content
       } else {
         const accountInfo: ProjectAccount = await response.json();
 
-        setSearchResultAccounts([accountInfo]);
+        getIsMounted() && setSearchResultAccounts([accountInfo]);
       }
     }
     setIsSearchLoading(false);
@@ -149,7 +151,7 @@ export const AccountsInput = (props: Props) => {
             <b>{account.number}</b>
             <br />
             <small>{account.name}</small>
-            <br/>
+            <br />
             Account Manager:{" "}
             <a href={`mailto:${account.accountManagerEmail}`}>
               {account.accountManagerName}

--- a/Harvest.Web/ClientApp/src/Requests/ApprovalContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/ApprovalContainer.tsx
@@ -13,6 +13,7 @@ import { formatCurrency } from "../Util/NumberFormatting";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDownload } from "@fortawesome/free-solid-svg-icons";
 import { usePromiseNotification } from "../Util/Notifications";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface RouteParams {
   projectId?: string;
@@ -27,6 +28,7 @@ export const ApprovalContainer = () => {
 
   const [notification, setNotification] = usePromiseNotification();
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
       const quoteResponse = await fetch(`/Quote/Get/${projectId}`);
@@ -34,7 +36,7 @@ export const ApprovalContainer = () => {
       if (quoteResponse.ok) {
         const projectWithQuote: ProjectWithQuote = await quoteResponse.json();
 
-        setProjectAndQuote(projectWithQuote);
+        getIsMounted() && setProjectAndQuote(projectWithQuote);
 
         // can only approve pendingApproval projects
         if (projectWithQuote.project.status !== "PendingApproval") {
@@ -44,7 +46,7 @@ export const ApprovalContainer = () => {
     };
 
     cb();
-  }, [history, projectId]);
+  }, [history, projectId, getIsMounted]);
 
   const approve = async () => {
     const model = { accounts };

--- a/Harvest.Web/ClientApp/src/Requests/SearchPerson.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/SearchPerson.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 
 import { AsyncTypeahead, Highlighter } from "react-bootstrap-typeahead";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 import { User } from "../types";
 
@@ -13,6 +14,7 @@ export const SearchPerson = (props: Props) => {
   const [isSearchLoading, setIsSearchLoading] = useState<boolean>(false);
   const [users, setUsers] = useState<User[]>([]);
 
+  const getIsMounted = useIsMounted();
   const onSearch = async (query: string) => {
     setIsSearchLoading(true);
 
@@ -20,14 +22,14 @@ export const SearchPerson = (props: Props) => {
 
     if (response.ok) {
       if (response.status === 204) {
-        setUsers([]); // no content means no match
+        getIsMounted() && setUsers([]); // no content means no match
       } else {
         const user: User = await response.json();
 
-        setUsers([user]);
+        getIsMounted() && setUsers([user]);
       }
     }
-    setIsSearchLoading(false);
+    getIsMounted() && setIsSearchLoading(false);
   };
 
   const onSelect = (selected: User[]) => {

--- a/Harvest.Web/ClientApp/src/Shared/FileUpload.tsx
+++ b/Harvest.Web/ClientApp/src/Shared/FileUpload.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { BlobServiceClient } from "@azure/storage-blob";
 import { BlobFile } from "../types";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface Props {
   disabled?: boolean;
@@ -39,18 +40,20 @@ export const FileUpload = (props: Props) => {
   // TODO: pass uploaded files up to parent.  perhaps allow add/remove
   const [sasUrl, setSasUrl] = useState<string>();
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     // grab the sas token right away
     const cb = async () => {
       const response = await fetch(`/File/GetUploadDetails`);
 
       if (response.ok) {
-        setSasUrl(await response.text());
+        const url = await response.text();
+        getIsMounted() && setSasUrl(url);
       }
     };
 
     cb();
-  }, []);
+  }, [getIsMounted]);
 
   const filesChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     const addedFiles = event.target.files;

--- a/Harvest.Web/ClientApp/src/Shared/UseIsMounted.ts
+++ b/Harvest.Web/ClientApp/src/Shared/UseIsMounted.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef, useCallback } from "react";
+
+export const useIsMounted = () => {
+  const isMounted = useRef(false);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+  // We want to always return the same function instance so that it doesn't trigger a rerender
+  // when passed into a dependencies array. useCallback will accomplish this as long as the
+  // MutableRefObject isMounted is not passed in, since the containing object is different
+  // on each render.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useCallback(() => isMounted.current, []);
+};

--- a/Harvest.Web/ClientApp/src/Tickets/RecentTicketsContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/RecentTicketsContainer.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import { Ticket } from "../types";
 import { TicketTable } from "./TicketTable";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface Props {
   projectId?: string;
@@ -13,6 +14,7 @@ export const RecentTicketsContainer = (props: Props) => {
   const [tickets, setTickets] = useState<Ticket[]>([]);
   const maxRows = 5;
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
       const response = await fetch(
@@ -20,12 +22,12 @@ export const RecentTicketsContainer = (props: Props) => {
       );
 
       if (response.ok) {
-        setTickets(await response.json());
+        getIsMounted() && setTickets(await response.json());
       }
     };
 
     cb();
-  }, [props.projectId]);
+  }, [props.projectId, getIsMounted]);
 
   return (
     <div className="card-content">

--- a/Harvest.Web/ClientApp/src/Tickets/TicketAttachments.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketAttachments.tsx
@@ -5,6 +5,7 @@ import { TicketAttachment, TicketDetails, BlobFile } from "../types";
 import { FormGroup, Label } from "reactstrap";
 import { FileUpload } from "../Shared/FileUpload";
 import { usePromiseNotification } from "../Util/Notifications";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface Props {
   ticket: TicketDetails;
@@ -25,6 +26,7 @@ export const TicketAttachments = (props: Props) => {
 
   const [notification, setNotification] = usePromiseNotification();
 
+  const getIsMounted = useIsMounted();
   const updateFiles = async (attachments: BlobFile[]) => {
     const request = fetch(
       `/Ticket/UploadFiles/${projectId}/${props.ticket.id}/`,
@@ -43,10 +45,11 @@ export const TicketAttachments = (props: Props) => {
 
     if (response.ok) {
       const data = (await response.json()) as TicketAttachment[];
+      if (getIsMounted()) {
+        setTicket({ ...ticket, attachments: [...ticket.attachments, ...data] });
 
-      setTicket({ ...ticket, attachments: [...ticket.attachments, ...data] });
-
-      setTicketLoc((ticket) => ({ ...ticket, newAttachments: [] }));
+        setTicketLoc((ticket) => ({ ...ticket, newAttachments: [] }));
+      }
     }
   };
 

--- a/Harvest.Web/ClientApp/src/Tickets/TicketCreate.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketCreate.tsx
@@ -9,6 +9,7 @@ import { ShowFor } from "../Shared/ShowFor";
 import { ticketSchema } from "../schemas";
 import { usePromiseNotification } from "../Util/Notifications";
 import { ValidationError } from "yup";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface RouteParams {
   projectId?: string;
@@ -26,25 +27,27 @@ export const TicketCreate = () => {
 
   const [notification, setNotification] = usePromiseNotification();
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
       const response = await fetch(`/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
-        setProject(proj);
-        setTicket((t) => ({ ...t, projectId: proj.id }));
+        if (getIsMounted()) {
+          setProject(proj);
+          setTicket((t) => ({ ...t, projectId: proj.id }));
+        }
       }
     };
 
     cb();
-  }, [projectId]);
+  }, [projectId, getIsMounted]);
 
   if (project === undefined) {
     return <div>Loading...</div>;
   }
 
-  
   const checkTicketValidity = async (inputs: any) => {
     try {
       await ticketSchema.validate(inputs, { abortEarly: false });
@@ -56,7 +59,6 @@ export const TicketCreate = () => {
   };
 
   const create = async () => {
-
     const ticketErrors = await checkTicketValidity(ticket);
 
     if (ticketErrors) {
@@ -165,17 +167,22 @@ export const TicketCreate = () => {
                 ></FileUpload>
               </FormGroup>
               <ul>
-            {inputErrors.map((error, i) => {
-              return (
-                <li className="text-danger" key={`error-${i}`}>
-                  {error}
-                </li>
-              );
-            })}
-            </ul>
+                {inputErrors.map((error, i) => {
+                  return (
+                    <li className="text-danger" key={`error-${i}`}>
+                      {error}
+                    </li>
+                  );
+                })}
+              </ul>
               <div className="row justify-content-center">
                 <ShowFor roles={["FieldManager", "Supervisor", "PI"]}>
-                  <Button className="btn-lg" color="primary" onClick={create} disabled={notification.pending}>
+                  <Button
+                    className="btn-lg"
+                    color="primary"
+                    onClick={create}
+                    disabled={notification.pending}
+                  >
                     Create New Ticket
                   </Button>
                 </ShowFor>

--- a/Harvest.Web/ClientApp/src/Tickets/TicketDetailContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketDetailContainer.tsx
@@ -9,6 +9,7 @@ import { TicketWorkNotesEdit } from "./TicketWorkNotesEdit";
 import { TicketReply } from "./TicketReply";
 import { Button } from "reactstrap";
 import { usePromiseNotification } from "../Util/Notifications";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface RouteParams {
   projectId: string;
@@ -23,18 +24,19 @@ export const TicketDetailContainer = () => {
 
   const [notification, setNotification] = usePromiseNotification();
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
       const response = await fetch(`/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
-        setProject(proj);
+        getIsMounted() && setProject(proj);
       }
     };
 
     cb();
-  }, [projectId]);
+  }, [projectId, getIsMounted]);
 
   useEffect(() => {
     const cb = async () => {
@@ -42,12 +44,12 @@ export const TicketDetailContainer = () => {
 
       if (response.ok) {
         const tick: TicketDetails = await response.json();
-        setTicket(tick);
+        getIsMounted() && setTicket(tick);
       }
     };
 
     cb();
-  }, [ticketId, projectId]);
+  }, [ticketId, projectId, getIsMounted]);
 
   if (project === undefined || ticket === undefined) {
     return <div>Loading...</div>;
@@ -65,7 +67,7 @@ export const TicketDetailContainer = () => {
       }
     );
     setNotification(request, "Closing Ticket", "Ticket Closed");
- 
+
     const response = await request;
 
     if (response.ok) {
@@ -144,7 +146,9 @@ export const TicketDetailContainer = () => {
               <TicketAttachments
                 ticket={ticket}
                 projectId={projectId}
-                setTicket={(ticket: TicketDetails) => setTicket(ticket)}
+                setTicket={(ticket: TicketDetails) =>
+                  getIsMounted() && setTicket(ticket)
+                }
                 attachments={ticket.attachments}
               />
               <hr />
@@ -153,7 +157,9 @@ export const TicketDetailContainer = () => {
               <TicketReply
                 ticket={ticket}
                 projectId={projectId}
-                setTicket={(ticket: TicketDetails) => setTicket(ticket)}
+                setTicket={(ticket: TicketDetails) =>
+                  getIsMounted() && setTicket(ticket)
+                }
               />
             </div>
           </div>

--- a/Harvest.Web/ClientApp/src/Tickets/TicketReply.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketReply.tsx
@@ -2,6 +2,7 @@
 import { Button, FormGroup, Input } from "reactstrap";
 import { TicketDetails, TicketMessage } from "../types";
 import { usePromiseNotification } from "../Util/Notifications";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface Props {
   ticket: TicketDetails;
@@ -17,6 +18,7 @@ export const TicketReply = (props: Props) => {
 
   const [notification, setNotification] = usePromiseNotification();
 
+  const getIsMounted = useIsMounted();
   const update = async () => {
     // TODO: validation
 
@@ -31,17 +33,19 @@ export const TicketReply = (props: Props) => {
         body: JSON.stringify(ticketMessage),
       }
     );
-    
+
     setNotification(request, "Saving Reply", "Reply Saved");
 
     const response = await request;
 
     if (response.ok) {
       const data = await response.json();
-      setTicket({ ...ticket, messages: [...ticket.messages, data] });
-      setTicketMessage({
-        message: "",
-      } as TicketMessage);
+      if (getIsMounted()) {
+        setTicket({ ...ticket, messages: [...ticket.messages, data] });
+        setTicketMessage({
+          message: "",
+        } as TicketMessage);
+      }
     }
   };
 

--- a/Harvest.Web/ClientApp/src/Tickets/TicketsContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketsContainer.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from "react-router-dom";
 import { Project, Ticket } from "../types";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { TicketTable } from "./TicketTable";
+import { useIsMounted } from "../Shared/UseIsMounted";
 
 interface RouteParams {
   projectId?: string;
@@ -13,30 +14,31 @@ export const TicketsContainer = () => {
   const [project, setProject] = useState<Project>();
   const [tickets, setTickets] = useState<Ticket[]>([]);
 
+  const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
       const response = await fetch(`/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
-        setProject(proj);
+        getIsMounted() && setProject(proj);
       }
     };
 
     cb();
-  }, [projectId]);
+  }, [projectId, getIsMounted]);
 
   useEffect(() => {
     const cb = async () => {
       const response = await fetch(`/Ticket/GetList?projectId=${projectId}`);
 
       if (response.ok) {
-        setTickets(await response.json());
+        getIsMounted() && setTickets(await response.json());
       }
     };
 
     cb();
-  }, [projectId]);
+  }, [projectId, getIsMounted]);
 
   if (project === undefined || tickets === undefined) {
     return <div>Loading...</div>;


### PR DESCRIPTION
My idea about copy/pasting a useEffect snippet was flawed. React gave a warning about needing to store the isMounted variable in a ref in order to not get erased on subsequent render. So I put it in a useIsMounted hook after all. For consistency I used the hook everywhere rather than the hook some places and
 ```
let isMounted=true; 
doAsyncStuff(); 
return () => {isMounted = false};
```
elsewhere.

I'm not married to this. I could just do the above in async effects and use the hook in the async functions.