### PR TITLE
Dynamic Code Splitting because of the PDF library

### DIFF
--- a/Harvest.Web/ClientApp/src/Invoices/InvoiceDetailContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/InvoiceDetailContainer.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useState } from "react";
+import React, { Suspense, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { PDFDownloadLink } from "@react-pdf/renderer";
 
 import { ProjectWithInvoice } from "../types";
-import { InvoicePDF } from "../Pdf/InvoicePDF";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { InvoiceDisplay } from "./InvoiceDisplay";
 import { useIsMounted } from "../Shared/UseIsMounted";
 
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faDownload } from "@fortawesome/free-solid-svg-icons";
+// Lazy load quote pdf link since it's a large JS file and causes a console warning
+const InvoicePDFLink = React.lazy(() => import("../Pdf/InvoicePDFLink"));
 
 interface RouteParams {
   invoiceId?: string;
@@ -59,15 +57,12 @@ export const InvoiceDetailContainer = () => {
         <div className="card-content">
           <InvoiceDisplay invoice={projectAndInvoice.invoice}></InvoiceDisplay>
         </div>
-
-        <PDFDownloadLink
-          document={<InvoicePDF invoice={projectAndInvoice.invoice} />}
-          fileName={`Invoice-${invoiceId}-Project-${projectAndInvoice.project.name}.pdf`}
-        >
-          <button className="btn btn-link btn-sm">
-            Download PDF <FontAwesomeIcon icon={faDownload} />
-          </button>
-        </PDFDownloadLink>
+        <Suspense fallback={<div>Generating PDF ...</div>}>
+          <InvoicePDFLink
+            invoice={projectAndInvoice.invoice}
+            fileName={`Invoice-${invoiceId}-Project-${projectAndInvoice.project.name}.pdf`}
+          ></InvoicePDFLink>
+        </Suspense>
       </div>
     </div>
   );

--- a/Harvest.Web/ClientApp/src/Pdf/InvoicePDFLink.tsx
+++ b/Harvest.Web/ClientApp/src/Pdf/InvoicePDFLink.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { PDFDownloadLink } from "@react-pdf/renderer";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faDownload } from "@fortawesome/free-solid-svg-icons";
+
+import { InvoicePDF } from "./InvoicePDF";
+import { Invoice } from "../types";
+
+interface Props {
+  invoice: Invoice;
+  fileName: string;
+}
+
+const InvoicePdfLink = (props: Props) => (
+  <PDFDownloadLink
+    document={<InvoicePDF invoice={props.invoice} />}
+    fileName={props.fileName}
+  >
+    <button className="btn btn-link btn-sm">
+      Download PDF <FontAwesomeIcon icon={faDownload} />
+    </button>
+  </PDFDownloadLink>
+);
+
+export default InvoicePdfLink;

--- a/Harvest.Web/ClientApp/src/Pdf/QuotePDFLink.tsx
+++ b/Harvest.Web/ClientApp/src/Pdf/QuotePDFLink.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { PDFDownloadLink } from "@react-pdf/renderer";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faDownload } from "@fortawesome/free-solid-svg-icons";
+
+import { QuotePDF } from "./QuotePDF";
+import { QuoteContent } from "../types";
+
+interface Props {
+  quote: QuoteContent;
+  fileName: string;
+}
+
+const QuotePdfLink = (props: Props) => (
+  <PDFDownloadLink
+    document={<QuotePDF quote={props.quote} />}
+    fileName={props.fileName}
+  >
+    <button className="btn btn-link btn-sm">
+      Download PDF <FontAwesomeIcon icon={faDownload} />
+    </button>
+  </PDFDownloadLink>
+);
+
+export default QuotePdfLink;

--- a/Harvest.Web/ClientApp/src/Requests/ApprovalContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/ApprovalContainer.tsx
@@ -1,19 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React, { Suspense, useEffect, useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
-import { PDFDownloadLink } from "@react-pdf/renderer";
 
 import { Project, ProjectAccount, ProjectWithQuote } from "../types";
 import { AccountsInput } from "./AccountsInput";
-import { QuotePDF } from "../Pdf/QuotePDF";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { QuoteDisplay } from "../Quotes/QuoteDisplay";
 import { RejectQuote } from "../Quotes/RejectQuote";
 import { formatCurrency } from "../Util/NumberFormatting";
 
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faDownload } from "@fortawesome/free-solid-svg-icons";
 import { usePromiseNotification } from "../Util/Notifications";
 import { useIsMounted } from "../Shared/UseIsMounted";
+
+// Lazy load quote pdf link since it's a large JS file and causes a console warning
+const QuotePDFLink = React.lazy(() => import("../Pdf/QuotePDFLink"));
 
 interface RouteParams {
   projectId?: string;
@@ -98,14 +97,12 @@ export const ApprovalContainer = () => {
               <h2 className="primary-font bold-font">
                 Quote Total: ${formatCurrency(projectAndQuote.quote.grandTotal)}
               </h2>
-              <PDFDownloadLink
-                document={<QuotePDF quote={projectAndQuote.quote} />}
-                fileName="Quote.pdf"
-              >
-                <button className="btn btn-link btn-sm pl-0">
-                  Download PDF <FontAwesomeIcon icon={faDownload} />
-                </button>
-              </PDFDownloadLink>
+              <Suspense fallback={<div>Generating PDF...</div>}>
+                <QuotePDFLink
+                  quote={projectAndQuote.quote}
+                  fileName="Quote.pdf"
+                ></QuotePDFLink>
+              </Suspense>
               <AccountsInput
                 accounts={accounts}
                 setAccounts={setAccounts}

--- a/Harvest.Web/Views/Shared/Components/DynamicScripts/DynamicScripts.cs
+++ b/Harvest.Web/Views/Shared/Components/DynamicScripts/DynamicScripts.cs
@@ -23,15 +23,16 @@ namespace Harvest.Web.Views.Shared.Components.DynamicScripts
             var files = _fileProvider.GetDirectoryContents("ClientApp/build/static/js");
 
             /* 
-             * Get all JS files in the static build folder
+             * Get the important JS files in the static build folder
              * Should include the following files:
+             * - 3.[hash].chunk.js (determined from the generated index.html by CRA)
              * - main.*.js
-             * - 2.[hash].chunk.js
              * - runtime-main.*.js
-             * - [number].[hash].chunk.js (for each additional chunk)
+
+             * Other chunks do not need to be included here, since they will be dynamically requested only when needed
 
              =======
-             We would like to inline the runtime-main file, then load 2.*.chunk.js, and then main.*.chunk.js
+             We would like to inline the runtime-main file, then load 3.*.chunk.js, and then main.*.chunk.js
             */
 
             var model = new DynamicScriptModel();
@@ -52,7 +53,7 @@ namespace Harvest.Web.Views.Shared.Components.DynamicScripts
 
             var scripts = new List<string>();
 
-            // read the 3.*.chunk.js files (maybe there is always just one?)
+            // read the 3.*.chunk.js files (There is probably only one, but doesn't hurt to be careful)
             scripts.AddRange(chunks.Where(c => c.StartsWith("3")));
 
             // now add in main.*.chunk.js

--- a/Harvest.Web/Views/Shared/Components/DynamicScripts/DynamicScripts.cs
+++ b/Harvest.Web/Views/Shared/Components/DynamicScripts/DynamicScripts.cs
@@ -47,10 +47,13 @@ namespace Harvest.Web.Views.Shared.Components.DynamicScripts
                 }
             }
 
+            // Get all the chunk files
+            var chunks = files.Where(f => Regex.IsMatch(f.Name, "^[0-9]*\\..*\\.chunk\\.js$")).Select(f => f.Name);
+
             var scripts = new List<string>();
 
-            // read the 2.*.chunk.js files (maybe there is always just one?)
-            scripts.AddRange(files.Where(f => Regex.IsMatch(f.Name, "^.*2\\..*\\.chunk\\.js$")).Select(f => f.Name));
+            // read the 3.*.chunk.js files (maybe there is always just one?)
+            scripts.AddRange(chunks.Where(c => c.StartsWith("3")));
 
             // now add in main.*.chunk.js
             scripts.AddRange(files.Where(f => Regex.IsMatch(f.Name, "^.*main\\..*\\.chunk\\.js$")).Select(f => f.Name));


### PR DESCRIPTION
The react-pdf library is adding 812KB to our JS, while our entire app, including vendor JS, is otherwise 318KB.  Additionally, the pdf lib gives an ASM.js warning in the console which is annoying.

So, my solution is to use code-splitting to move the PDF components into dynamically loaded components.  There are quite a few ways to do this, but using `React.lazy()` seemed like an easy plan. See https://reactjs.org/docs/code-splitting.html.

This works really well, and this all made me also realize there was no reason for me to include all chunks on the rendered layout page by default.  I can just include the runtime, main, and primary chunk (determined by whatever `npm run build` spits out) and everything will work, it'll only load what is needed, and it'll dynamically load other stuff later.
