### PR TITLE
Jcs/hacky date sort filter fix

### DIFF
--- a/Harvest.Web/ClientApp/src/Expenses/ExpenseTable.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ExpenseTable.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { Column, TableState } from "react-table";
+import { Cell, Column, TableState } from "react-table";
 import { Button } from "reactstrap";
 import { ReactTable } from "../Shared/ReactTable";
 import { ReactTableUtil } from "../Shared/TableUtil";
@@ -56,9 +56,13 @@ export const ExpenseTable = (props: Props) => {
       {
         Header: "Entered on",
         accessor: (row) =>
-          row.createdOn === undefined
-            ? "N/A"
-            : new Date(row.createdOn).toLocaleDateString(),
+          `${row.createdOn} ${
+            row.createdOn ? new Date(row.createdOn).toLocaleDateString() : ""
+          }`, //This can't be null in the db
+        Cell: (data: Cell<Expense>) =>
+          data.row.original.createdOn
+            ? new Date(data.row.original.createdOn).toLocaleDateString()
+            : "N/A",
       },
       {
         Header: "Delete",

--- a/Harvest.Web/ClientApp/src/Invoices/InvoiceTable.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/InvoiceTable.tsx
@@ -30,7 +30,10 @@ export const InvoiceTable = (props: Props) => {
       },
       {
         Header: "Created",
-        accessor: (row) => new Date(row.createdOn).toLocaleDateString(),
+        accessor: (row) =>
+          `${row.createdOn} ${new Date(row.createdOn).toLocaleDateString()}`,
+        Cell: (data: Cell<Invoice>) =>
+          new Date(data.row.original.createdOn).toLocaleDateString(),
       },
       {
         Header: "Total",

--- a/Harvest.Web/ClientApp/src/Projects/ProjectTable.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectTable.tsx
@@ -70,7 +70,7 @@ export const ProjectTable = (props: Props) => {
         accessor: (row) =>
           `${row.end} ${new Date(row.end).toLocaleDateString()}`,
         Cell: (data: Cell<Project>) =>
-          new Date(data.value).toLocaleDateString(),
+          new Date(data.row.original.end).toLocaleDateString(),
       },
       {
         Header: "Status",

--- a/Harvest.Web/ClientApp/src/Projects/ProjectTable.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectTable.tsx
@@ -59,14 +59,16 @@ export const ProjectTable = (props: Props) => {
       {
         id: "startDate",
         Header: "Start",
-        accessor: "start",
+        accessor: (row) =>
+          `${row.start} ${new Date(row.start).toLocaleDateString()}`,
         Cell: (data: Cell<Project>) =>
-          new Date(data.value).toLocaleDateString(),
+          new Date(data.row.original.start).toLocaleDateString(),
       },
       {
         id: "endDate",
         Header: "End",
-        accessor: "end",
+        accessor: (row) =>
+          `${row.end} ${new Date(row.end).toLocaleDateString()}`,
         Cell: (data: Cell<Project>) =>
           new Date(data.value).toLocaleDateString(),
       },

--- a/Harvest.Web/ClientApp/src/Tickets/TicketTable.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketTable.tsx
@@ -33,19 +33,32 @@ export const TicketTable = (props: Props) => {
       },
       {
         Header: "Created",
-        accessor: (row) => new Date(row.createdOn).toLocaleDateString(),
+        accessor: (row) =>
+          `${row.createdOn} ${new Date(row.createdOn).toLocaleDateString()}`,
+        Cell: (data: Cell<Ticket>) =>
+          new Date(data.row.original.createdOn).toLocaleDateString(),
       },
       {
         Header: "Updated",
-        accessor: "updatedOn",
+        accessor: (row) =>
+          `${row.updatedOn} ${
+            row.updatedOn ? new Date(row.updatedOn).toLocaleDateString() : ""
+          }`,
         Cell: (data: Cell<Ticket>) =>
-          data.value ? new Date(data.value).toLocaleDateString() : "",
+          data.row.original.updatedOn
+            ? new Date(data.row.original.updatedOn).toLocaleDateString()
+            : "",
       },
       {
         Header: "Due",
-        accessor: "dueDate",
+        accessor: (row) =>
+          `${row.dueDate} ${
+            row.dueDate ? new Date(row.dueDate).toLocaleDateString() : ""
+          }`,
         Cell: (data: Cell<Ticket>) =>
-          data.value ? new Date(data.value).toLocaleDateString() : "",
+          data.row.original.dueDate
+            ? new Date(data.row.original.dueDate).toLocaleDateString()
+            : "",
       },
       {
         Header: "Subject",


### PR DESCRIPTION
Resolve #517 
This works, because the accessor data looks like this:
2021-12-04T08:00:00 12/4/2021

so sorting is always correct, and if you filter you can use 12-04 or 12/4 etc.