### PR TITLE
Validate All

### DIFF
--- a/Harvest.Web/ClientApp/src/FormValidation/UseInputValidator.tsx
+++ b/Harvest.Web/ClientApp/src/FormValidation/UseInputValidator.tsx
@@ -209,12 +209,12 @@ export function useInputValidator<T>(
     onBlurValue(name, e.target.value);
   };
 
-  const onBlurValue = (name: TKey, value: T[TKey] | undefined | string) => {
+  const onBlurValue = (name: TKey, value?: T[TKey] | string) => {
     setFormIsTouched(true);
     if (!touchedFields.some((f) => f === name)) {
       setTouchedFields([...touchedFields, name]);
     }
-    validateField(name, value as T[TKey]);
+    validateField(name, (value || values[name]) as T[TKey]);
   };
 
   const fieldIsTouched = (name: TKey) => touchedFields.some((f) => f === name);

--- a/Harvest.Web/ClientApp/src/FormValidation/UseInputValidator.tsx
+++ b/Harvest.Web/ClientApp/src/FormValidation/UseInputValidator.tsx
@@ -55,8 +55,9 @@ export function useInputValidator<T>(
 
   useEffect(() => {
     const errorCount = errors.flatMap((e) => e.errors).length;
-    const previousErrorCount = (previousErrors || []).flatMap((e) => e.errors)
-      .length;
+    const previousErrorCount = (previousErrors || []).flatMap(
+      (e) => e.errors
+    ).length;
     if (errorCount !== previousErrorCount) {
       setFormErrorCount(
         (formErrorCount) => formErrorCount + errorCount - previousErrorCount
@@ -66,7 +67,7 @@ export function useInputValidator<T>(
 
   const validateFieldImpl = useCallback(
     async (name: TKey, value: T[TKey]) => {
-      const newValues = ({ ...values, [name]: value } as unknown) as T;
+      const newValues = { ...values, [name]: value } as unknown as T;
       setValues(newValues);
       try {
         await schema.validateAt(name as string, newValues);
@@ -88,10 +89,8 @@ export function useInputValidator<T>(
 
   const validateField = useDebounceCallback(validateFieldImpl, 250);
 
-  const registeredNames = useRef<TKey[]>([]);
-  const validatorCallbacks = useRef<ValidatorCallbacks>(
-    {} as ValidatorCallbacks
-  );
+  const registeredNames = useRef([] as TKey[]);
+  const validatorCallbacks = useRef({} as ValidatorCallbacks);
 
   useEffect(() => {
     const cb = validatorCallbacks;
@@ -175,35 +174,33 @@ export function useInputValidator<T>(
     validateField(name, value);
   };
 
-  const onChange = (
-    name: TKey,
-    handler: ChangeEventHandler<HTMLInputElement> | null = null
-  ) => (e: ChangeEvent<HTMLInputElement>) => {
-    handler && handler(e);
-    // If T[TKey] is a number, this doesn't actually convert the string to a number.
-    // But yup doesn't seem to mind, and that's what counts.
-    valueChanged(name, (e.target.value as unknown) as T[TKey]);
-    setFormIsDirty(true);
-    if (!dirtyFields.some((f) => f === name)) {
-      setDirtyFields([...dirtyFields, name]);
-    }
-  };
+  const onChange =
+    (name: TKey, handler: ChangeEventHandler<HTMLInputElement> | null = null) =>
+    (e: ChangeEvent<HTMLInputElement>) => {
+      handler && handler(e);
+      // If T[TKey] is a number, this doesn't actually convert the string to a number.
+      // But yup doesn't seem to mind, and that's what counts.
+      valueChanged(name, e.target.value as unknown as T[TKey]);
+      setFormIsDirty(true);
+      if (!dirtyFields.some((f) => f === name)) {
+        setDirtyFields([...dirtyFields, name]);
+      }
+    };
 
   // Some components return the selected element in the onChange function so
   // we have to create an onChange function that handles that
-  const onChangeValue = (
-    name: TKey,
-    handler: ((value: any) => void) | null = null
-  ) => (value: any) => {
-    handler && handler(value);
-    // If T[TKey] is a number, this doesn't actually convert the string to a number.
-    // But yup doesn'tx seem to mind, and that's what counts.
-    valueChanged(name, value as T[TKey]);
-    setFormIsDirty(true);
-    if (!dirtyFields.some((f) => f === name)) {
-      setDirtyFields([...dirtyFields, name]);
-    }
-  };
+  const onChangeValue =
+    (name: TKey, handler: ((value: any) => void) | null = null) =>
+    (value: any) => {
+      handler && handler(value);
+      // If T[TKey] is a number, this doesn't actually convert the string to a number.
+      // But yup doesn'tx seem to mind, and that's what counts.
+      valueChanged(name, value as T[TKey]);
+      setFormIsDirty(true);
+      if (!dirtyFields.some((f) => f === name)) {
+        setDirtyFields([...dirtyFields, name]);
+      }
+    };
 
   const onBlur = (name: TKey) => (e: FocusEvent<HTMLInputElement>) => {
     onBlurValue(name, e.target.value);

--- a/Harvest.Web/ClientApp/src/FormValidation/ValidationProvider.tsx
+++ b/Harvest.Web/ClientApp/src/FormValidation/ValidationProvider.tsx
@@ -1,6 +1,5 @@
 ﻿import React, {
   useState,
-  useEffect,
   Dispatch,
   MutableRefObject,
   SetStateAction,
@@ -34,25 +33,6 @@ export const useOrCreateValidationContext = (
   const [formErrorCount, setFormErrorCount] = useState(0);
   const [formIsTouched, setFormIsTouched] = useState(false);
   const [formIsDirty, setFormIsDirty] = useState(false);
-  const [contextIsReset, setcontextIsReset] = useState(false);
-  const resetContext = () => {
-    setFormErrorCount(0);
-    setFormIsTouched(false);
-    setFormIsDirty(false);
-    setcontextIsReset(true);
-  };
-
-  useEffect(() => {
-    if ((formErrorCount || formIsTouched || formIsDirty) && contextIsReset) {
-      setcontextIsReset(false);
-    }
-  }, [
-    formErrorCount,
-    formIsTouched,
-    formIsDirty,
-    contextIsReset,
-    setcontextIsReset,
-  ]);
 
   // a ref of array of refs
   // this is the only way to ensure the array does not get replaced on rerenders

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -37,7 +37,7 @@ export const QuoteContainer = () => {
   const [quote, setQuote] = useState<QuoteContent>(new QuoteContentImpl());
   const [rates, setRates] = useState<Rate[]>([]);
 
-  const { formErrorCount, context } = useInputValidator(
+  const { formErrorCount, context, validateAll } = useInputValidator(
     quoteContentSchema,
     quote
   );
@@ -153,6 +153,10 @@ export const QuoteContainer = () => {
   ]);
 
   const save = async (submit: boolean) => {
+    const errors = await validateAll();
+    if (errors.length > 0) {
+      return;
+    }
     // remove unused workitems and empty activities and apply to state only after successfully saving
     quote.activities.forEach(
       (a) =>

--- a/Harvest.Web/ClientApp/src/Requests/Crops.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/Crops.tsx
@@ -1,25 +1,25 @@
 import React, { useEffect, useState } from "react";
 
-import { Typeahead } from "react-bootstrap-typeahead";
+import { Typeahead, TypeaheadProps } from "react-bootstrap-typeahead";
 import { CropType } from "../types";
 
-interface Props {
+interface Props extends Pick<TypeaheadProps<string>, "onBlur"> {
   crops: string;
-  setCrops: (crops: string) => void;
+  onChange: (crops: string) => void;
   cropType: CropType;
 }
 
 const splitCrops = (crop: string) => (crop ? crop.split(",") : []);
 
 export const Crops = (props: Props) => {
-  const [crops, setCrops] = useState<string[]>(splitCrops(props.crops));
+  const [crops, onChange] = useState<string[]>(splitCrops(props.crops));
   const [options, setOptions] = useState<string[]>([]);
 
   useEffect(() => {
     if (!props.crops) {
-      setCrops([]);
+      onChange([]);
     } else {
-      setCrops(splitCrops(props.crops));
+      onChange(splitCrops(props.crops));
     }
   }, [props.crops]);
 
@@ -34,9 +34,9 @@ export const Crops = (props: Props) => {
         typeof s === "string" ? s : s.label
       );
 
-      props.setCrops(selectedStrings.join(","));
+      props.onChange(selectedStrings.join(","));
     } else {
-      props.setCrops(""); //If it is cleared out...
+      props.onChange(""); //If it is cleared out...
     }
   };
 
@@ -49,6 +49,7 @@ export const Crops = (props: Props) => {
       options={options}
       placeholder="Search for common crops or add your own"
       onChange={onSelect}
+      onBlur={props.onBlur}
     />
   );
 };

--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useEffect, useMemo, useState } from "react";
 import { useHistory, useParams } from "react-router";
 import { Link } from "react-router-dom";
 import { Button, FormGroup, Input, Label } from "reactstrap";
-import { ValidationError } from "yup";
 import DatePicker from "react-date-picker";
 
 import { FileUpload } from "../Shared/FileUpload";
@@ -152,10 +151,7 @@ export const RequestContainer = () => {
           )}
           <div className={originalProject && "card-green-bg"}>
             <div className="row justify-content-center">
-              <div
-                className="col-md-6 card-wrapper no-green mt-4 mb-4"
-                style={{ overflow: "visible" }}
-              >
+              <div className="col-md-6 card-wrapper no-green mt-4 mb-4">
                 <div className="card-content">
                   <h2>
                     {projectId

--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
@@ -14,6 +14,7 @@ import AppContext from "../Shared/AppContext";
 import { usePromiseNotification } from "../Util/Notifications";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { useInputValidator, ValidationProvider } from "../FormValidation";
 
 interface RouteParams {
   projectId?: string;
@@ -30,19 +31,20 @@ export const RequestContainer = () => {
     principalInvestigator: userDetail,
   } as Project);
   const [originalProject, setOriginalProject] = useState<Project>();
-  const [inputErrors, setInputErrors] = useState<string[]>([]);
+
+  const {
+    context,
+    validateAll,
+    formErrorCount,
+    formIsDirty,
+    onChange,
+    onChangeValue,
+    onBlur,
+    onBlurValue,
+    InputErrorMessage,
+  } = useInputValidator(requestSchema, project);
 
   const [notification, setNotification] = usePromiseNotification();
-
-  const checkRequestValidity = async (inputs: any) => {
-    try {
-      await requestSchema.validate(inputs, { abortEarly: false });
-    } catch (err) {
-      if (err instanceof ValidationError) {
-        return err.errors;
-      }
-    }
-  };
 
   const getIsMounted = useIsMounted();
   useEffect(() => {
@@ -73,26 +75,9 @@ export const RequestContainer = () => {
   const create = async () => {
     // TODO: validation, loading spinner
     // create a new project
-    const requestErrors = await checkRequestValidity(project);
+    const requestErrors = await validateAll();
 
-    if (requestErrors) {
-      if (requestErrors.length > 0) {
-        setInputErrors(requestErrors);
-
-        if (new Date(project.start) > new Date(project.end)) {
-          setInputErrors((oldErrors) => [
-            ...oldErrors,
-            "Start date must be before end date",
-          ]);
-        }
-        return;
-      } else {
-        setInputErrors([]);
-      }
-    }
-
-    if (new Date(project.start) > new Date(project.end)) {
-      setInputErrors(["Start date must be before end date"]);
+    if (requestErrors.length > 0) {
       return;
     }
 
@@ -158,172 +143,196 @@ export const RequestContainer = () => {
         </div>
       )}
       <div className={originalProject && "card-wrapper"}>
-        {originalProject !== undefined && (
-          <ProjectHeader
-            project={originalProject}
-            title={"Original Field Request #" + (originalProject?.id || "")}
-          />
-        )}
-        <div className={originalProject && "card-green-bg"}>
-          <div className="row justify-content-center">
-            <div className="col-md-6 card-wrapper no-green mt-4 mb-4">
-              <div className="card-content">
-                <h2>
-                  {projectId ? "Create Change Request" : "Create Field Request"}
-                </h2>
-                <div className="row">
-                  <div className="col-md-6">
-                    <div className="form-group">
-                      <Label>When to Start?</Label>
-                      <div className="input-group" style={{ zIndex: 9000 }}>
-                        <DatePicker
-                          format="MM/dd/yyyy"
-                          required={false}
-                          clearIcon={null}
-                          value={project.start}
-                          onChange={(date: Date) =>
-                            setProject({ ...project, start: date })
-                          }
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div className="col-md-6">
-                    <FormGroup>
-                      <Label>When to Finish?</Label>
-                      <div className="input-group" style={{ zIndex: 9000 }}>
-                        <DatePicker
-                          format="MM/dd/yyyy"
-                          required={false}
-                          clearIcon={null}
-                          value={project.end}
-                          onChange={(date: Date) =>
-                            setProject({ ...project, end: date })
-                          }
-                        />
-                      </div>
-                    </FormGroup>
-                  </div>
-                </div>
-                <FormGroup>
-                  <Label>Which type of crop will we grow?</Label>
-                  <div className="custom-control custom-radio">
-                    <input
-                      type="radio"
-                      id="rowCropInput"
-                      name="rowCropInput"
-                      className="custom-control-input"
-                      style={{ zIndex: 1 }} //prevent class custom-control-input from blocking mouse clicks
-                      value="Row"
-                      checked={project.cropType === "Row"}
-                      onChange={handleCropTypeChange}
-                    />
-                    <label
-                      className="custom-control-label"
-                      htmlFor="rowCropInput"
-                    >
-                      Row Crops
-                    </label>
-                  </div>
-                  <div className="custom-control custom-radio">
-                    <input
-                      type="radio"
-                      id="treeCropInput"
-                      name="treeCropInput"
-                      className="custom-control-input"
-                      style={{ zIndex: 1 }} //prevent class custom-control-input from blocking mouse clicks
-                      value="Tree"
-                      checked={project.cropType === "Tree"}
-                      onChange={handleCropTypeChange}
-                    />
-                    <label
-                      className="custom-control-label"
-                      htmlFor="treeCropInput"
-                    >
-                      Tree Crops
-                    </label>
-                  </div>
-                </FormGroup>
-
-                <FormGroup tag="fieldset">
-                  <Label>What crop(s) will we grow?</Label>
-                  <Crops
-                    crops={project.crop}
-                    setCrops={(c) => setProject({ ...project, crop: c })}
-                    cropType={project.cropType}
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label>Who will be the PI?</Label>
-                  <SearchPerson
-                    user={project.principalInvestigator}
-                    setUser={(u) =>
-                      setProject({ ...project, principalInvestigator: u })
-                    }
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label>Want to attach any files?</Label>
-                  <FileUpload
-                    files={project.attachments || []}
-                    setFiles={(f) =>
-                      setProject({ ...project, attachments: [...f] })
-                    }
-                    updateFile={(f) =>
-                      setProject((proj) => {
-                        // update just one specific file from project p
-                        proj.attachments[
-                          proj.attachments.findIndex(
-                            (file) => file.identifier === f.identifier
-                          )
-                        ] = { ...f };
-
-                        return { ...proj, attachments: [...proj.attachments] };
-                      })
-                    }
-                  />
-                </FormGroup>
-
-                <FormGroup>
-                  <Label>What are the requirements?</Label>
-                  <Input
-                    type="textarea"
-                    name="text"
-                    id="requirements"
-                    value={project.requirements}
-                    onChange={(e) =>
-                      setProject({ ...project, requirements: e.target.value })
-                    }
-                    placeholder="Enter a full description of your requirements"
-                  />
-                </FormGroup>
-                <ul>
-                  {inputErrors.map((error, i) => {
-                    return (
-                      <li style={{ color: "red" }} key={`error-${i}`}>
-                        {error}
-                      </li>
-                    );
-                  })}
-                </ul>
-                <div className="row justify-content-center">
-                  <Button
-                    className="btn-lg"
-                    color="primary"
-                    onClick={create}
-                    disabled={!isFilledIn || notification.pending}
-                  >
+        <ValidationProvider context={context}>
+          {originalProject !== undefined && (
+            <ProjectHeader
+              project={originalProject}
+              title={"Original Field Request #" + (originalProject?.id || "")}
+            />
+          )}
+          <div className={originalProject && "card-green-bg"}>
+            <div className="row justify-content-center">
+              <div
+                className="col-md-6 card-wrapper no-green mt-4 mb-4"
+                style={{ overflow: "visible" }}
+              >
+                <div className="card-content">
+                  <h2>
                     {projectId
                       ? "Create Change Request"
                       : "Create Field Request"}
-                  </Button>
+                  </h2>
+                  <div className="row">
+                    <div className="col-md-6">
+                      <div className="form-group">
+                        <Label>When to Start?</Label>
+                        <div
+                          className="input-group"
+                          style={{ zIndex: 9000 }}
+                          onBlur={() => onBlurValue("start")}
+                        >
+                          <DatePicker
+                            format="MM/dd/yyyy"
+                            required={false}
+                            clearIcon={null}
+                            value={project.start}
+                            onChange={onChangeValue("start", (date: Date) =>
+                              setProject({ ...project, start: date })
+                            )}
+                          />
+                        </div>
+                        <InputErrorMessage name="start" />
+                      </div>
+                    </div>
+                    <div className="col-md-6">
+                      <FormGroup>
+                        <Label>When to Finish?</Label>
+                        <div
+                          className="input-group"
+                          style={{ zIndex: 9000 }}
+                          onBlur={() => onBlurValue("end")}
+                        >
+                          <DatePicker
+                            format="MM/dd/yyyy"
+                            required={false}
+                            clearIcon={null}
+                            value={project.end}
+                            onChange={onChangeValue("end", (date: Date) =>
+                              setProject({ ...project, end: date })
+                            )}
+                          />
+                        </div>
+                        <InputErrorMessage name="end" />
+                      </FormGroup>
+                    </div>
+                  </div>
+                  <FormGroup>
+                    <Label>Which type of crop will we grow?</Label>
+                    <div className="custom-control custom-radio">
+                      <input
+                        type="radio"
+                        id="rowCropInput"
+                        name="rowCropInput"
+                        className="custom-control-input"
+                        style={{ zIndex: 1 }} //prevent class custom-control-input from blocking mouse clicks
+                        value="Row"
+                        checked={project.cropType === "Row"}
+                        onChange={handleCropTypeChange}
+                      />
+                      <label
+                        className="custom-control-label"
+                        htmlFor="rowCropInput"
+                      >
+                        Row Crops
+                      </label>
+                    </div>
+                    <div className="custom-control custom-radio">
+                      <input
+                        type="radio"
+                        id="treeCropInput"
+                        name="treeCropInput"
+                        className="custom-control-input"
+                        style={{ zIndex: 1 }} //prevent class custom-control-input from blocking mouse clicks
+                        value="Tree"
+                        checked={project.cropType === "Tree"}
+                        onChange={handleCropTypeChange}
+                      />
+                      <label
+                        className="custom-control-label"
+                        htmlFor="treeCropInput"
+                      >
+                        Tree Crops
+                      </label>
+                    </div>
+                  </FormGroup>
+
+                  <FormGroup tag="fieldset">
+                    <Label>What crop(s) will we grow?</Label>
+                    <Crops
+                      crops={project.crop}
+                      onChange={onChangeValue("crop", (c) =>
+                        setProject({ ...project, crop: c })
+                      )}
+                      cropType={project.cropType}
+                      onBlur={() => onBlurValue("crop")}
+                    />
+                    <InputErrorMessage name="crop" />
+                  </FormGroup>
+
+                  <FormGroup>
+                    <Label>Who will be the PI?</Label>
+                    <SearchPerson
+                      user={project.principalInvestigator}
+                      onChange={onChangeValue("principalInvestigator", (u) =>
+                        setProject({ ...project, principalInvestigator: u })
+                      )}
+                      onBlur={() => onBlurValue("principalInvestigator")}
+                    />
+                    <InputErrorMessage name="principalInvestigator" />
+                  </FormGroup>
+
+                  <FormGroup>
+                    <Label>Want to attach any files?</Label>
+                    <FileUpload
+                      files={project.attachments || []}
+                      setFiles={(f) =>
+                        setProject({ ...project, attachments: [...f] })
+                      }
+                      updateFile={(f) =>
+                        setProject((proj) => {
+                          // update just one specific file from project p
+                          proj.attachments[
+                            proj.attachments.findIndex(
+                              (file) => file.identifier === f.identifier
+                            )
+                          ] = { ...f };
+
+                          return {
+                            ...proj,
+                            attachments: [...proj.attachments],
+                          };
+                        })
+                      }
+                    />
+                  </FormGroup>
+
+                  <FormGroup>
+                    <Label>What are the requirements?</Label>
+                    <Input
+                      type="textarea"
+                      name="text"
+                      id="requirements"
+                      value={project.requirements}
+                      onChange={onChange("requirements", (e) =>
+                        setProject({ ...project, requirements: e.target.value })
+                      )}
+                      onBlur={onBlur("requirements")}
+                      placeholder="Enter a full description of your requirements"
+                    />
+                    <InputErrorMessage name="requirements" />
+                  </FormGroup>
+                  <div className="row justify-content-center">
+                    <Button
+                      className="btn-lg"
+                      color="primary"
+                      onClick={create}
+                      disabled={
+                        !isFilledIn ||
+                        notification.pending ||
+                        formErrorCount > 0 ||
+                        !formIsDirty
+                      }
+                    >
+                      {projectId
+                        ? "Create Change Request"
+                        : "Create Field Request"}
+                    </Button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
+        </ValidationProvider>
       </div>
     </div>
   );

--- a/Harvest.Web/ClientApp/src/Requests/SearchPerson.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/SearchPerson.tsx
@@ -1,18 +1,22 @@
 import React, { useState } from "react";
 
-import { AsyncTypeahead, Highlighter } from "react-bootstrap-typeahead";
+import {
+  AsyncTypeahead,
+  Highlighter,
+  TypeaheadProps,
+} from "react-bootstrap-typeahead";
 import { useIsMounted } from "../Shared/UseIsMounted";
 
 import { User } from "../types";
 
-interface Props {
+interface Props extends Pick<TypeaheadProps<string>, "onBlur"> {
   user?: User;
-  setUser: (user: User) => void;
+  onChange: (user: User | undefined) => void;
 }
 
 export const SearchPerson = (props: Props) => {
   const [isSearchLoading, setIsSearchLoading] = useState<boolean>(false);
-  const [users, setUsers] = useState<User[]>([]);
+  const [users, onChanges] = useState<User[]>([]);
 
   const getIsMounted = useIsMounted();
   const onSearch = async (query: string) => {
@@ -22,21 +26,22 @@ export const SearchPerson = (props: Props) => {
 
     if (response.ok) {
       if (response.status === 204) {
-        getIsMounted() && setUsers([]); // no content means no match
+        getIsMounted() && onChanges([]); // no content means no match
       } else {
         const user: User = await response.json();
 
-        getIsMounted() && setUsers([user]);
+        getIsMounted() && onChanges([user]);
       }
     }
     getIsMounted() && setIsSearchLoading(false);
   };
 
   const onSelect = (selected: User[]) => {
-    // TODO: need a way to clear out selected user -- perhaps we allow null/undefined to be passed up the line?
     if (selected && selected.length === 1) {
       // found our match
-      props.setUser(selected[0]);
+      props.onChange(selected[0]);
+    } else {
+      props.onChange(undefined);
     }
   };
 
@@ -67,6 +72,7 @@ export const SearchPerson = (props: Props) => {
       onSearch={onSearch}
       onChange={onSelect}
       options={users}
+      onBlur={props.onBlur}
     />
   );
 };

--- a/Harvest.Web/ClientApp/src/Requests/SearchPerson.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/SearchPerson.tsx
@@ -16,7 +16,7 @@ interface Props extends Pick<TypeaheadProps<string>, "onBlur"> {
 
 export const SearchPerson = (props: Props) => {
   const [isSearchLoading, setIsSearchLoading] = useState<boolean>(false);
-  const [users, onChanges] = useState<User[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
 
   const getIsMounted = useIsMounted();
   const onSearch = async (query: string) => {
@@ -26,11 +26,11 @@ export const SearchPerson = (props: Props) => {
 
     if (response.ok) {
       if (response.status === 204) {
-        getIsMounted() && onChanges([]); // no content means no match
+        getIsMounted() && setUsers([]); // no content means no match
       } else {
         const user: User = await response.json();
 
-        getIsMounted() && onChanges([user]);
+        getIsMounted() && setUsers([user]);
       }
     }
     getIsMounted() && setIsSearchLoading(false);

--- a/Harvest.Web/ClientApp/src/Shared/ProjectHeader.tsx
+++ b/Harvest.Web/ClientApp/src/Shared/ProjectHeader.tsx
@@ -20,9 +20,13 @@ export const ProjectHeader = (props: Props) => {
       return (
         <p>
           {`${project.requirements.substring(0, 256)} ...`}
-          <a href="#" onClick={toggleModal}>
+          <Button
+            className="btn-link btn-sm"
+            color="link"
+            onClick={toggleModal}
+          >
             See More
-          </a>
+          </Button>
         </p>
       );
     } else {

--- a/Harvest.Web/ClientApp/src/Tickets/TicketCreate.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketCreate.tsx
@@ -156,6 +156,10 @@ export const TicketCreate = () => {
                       onBlur={() => onBlurValue("dueDate", ticket.dueDate)}
                     >
                       <DatePicker
+                        className={getClassName(
+                          "dueDate",
+                          "react-date-picker__wrapper"
+                        )}
                         format="MM/dd/yyyy"
                         required={false}
                         clearIcon={null}

--- a/Harvest.Web/ClientApp/src/Tickets/TicketCreate.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketCreate.tsx
@@ -148,8 +148,8 @@ export const TicketCreate = () => {
                         required={false}
                         clearIcon={null}
                         value={ticket.dueDate}
-                        onChange={onChangeValue("dueDate", (date) =>
-                          setTicket({ ...ticket, dueDate: date as Date })
+                        onChange={onChangeValue("dueDate", (date: Date) =>
+                          setTicket({ ...ticket, dueDate: date })
                         )}
                       />
                     </div>

--- a/Harvest.Web/ClientApp/src/Util/Calculations.ts
+++ b/Harvest.Web/ClientApp/src/Util/Calculations.ts
@@ -25,3 +25,5 @@ export const getDaysDiff = (date1: Date, date2: Date) =>
   (date1.getTime() - date2.getTime()) / millisecondsPerDay;
 export const getHoursDiff = (date1: Date, date2: Date) =>
   (date1.getTime() - date2.getTime()) / millisecondsPerHour;
+export const addDays = (date: Date, days: number) =>
+  new Date(date.getTime() + days * millisecondsPerDay);

--- a/Harvest.Web/ClientApp/src/errorMessages.ts
+++ b/Harvest.Web/ClientApp/src/errorMessages.ts
@@ -17,4 +17,6 @@ export const ErrorMessages = {
   NumberAcresRequired: "Number of acres is required.",
   AcreageRateRequired: "Acreage rate is required.",
   YearsNegative: "Years cannot be negative.",
+  EndDateAfterStartDate: "End date must come after start date.",
+  PIRequired: "Prinipal investigator is required",
 };

--- a/Harvest.Web/ClientApp/src/sass/_layout.scss
+++ b/Harvest.Web/ClientApp/src/sass/_layout.scss
@@ -18,7 +18,6 @@ body {
   border-right: 1px solid $borders;
   border-bottom: 1px solid $borders;
   box-shadow: $box-shadow;
-  overflow: hidden;
   &.no-green {
     border-top: 8px solid #fff;
   }

--- a/Harvest.Web/ClientApp/src/schemas.ts
+++ b/Harvest.Web/ClientApp/src/schemas.ts
@@ -1,13 +1,6 @@
 import * as yup from "yup";
 import { SchemaOf } from "yup";
-import {
-  BlobFile,
-  RequestInput,
-  User,
-  TicketInput,
-  WorkItem,
-  Activity,
-} from "./types";
+import { BlobFile, User, TicketInput, WorkItem, Activity } from "./types";
 import { ErrorMessages } from "./errorMessages";
 import { addDays } from "./Util/Calculations";
 

--- a/Harvest.Web/ClientApp/src/schemas.ts
+++ b/Harvest.Web/ClientApp/src/schemas.ts
@@ -9,6 +9,10 @@ import {
   Activity,
 } from "./types";
 import { ErrorMessages } from "./errorMessages";
+import { addDays } from "./Util/Calculations";
+
+// @ts-ignore - override correct yup type
+export const requiredDateSchema: yup.SchemaOf<Date> = yup.date().required();
 
 export const investigatorSchema: SchemaOf<User> = yup.object().shape({
   id: yup.number().required(),
@@ -30,14 +34,19 @@ export const fileSchema: SchemaOf<BlobFile> = yup.object().shape({
   sasLink: yup.string(),
 });
 
-export const requestSchema: SchemaOf<RequestInput> = yup.object().shape({
+export const requestSchema = yup.object().shape({
   id: yup.number().required(),
-  start: yup.string().required(),
-  end: yup.string().required(),
+  start: requiredDateSchema,
+  end: requiredDateSchema.when("start", (start, yup) =>
+    yup.min(addDays(start, 1), ErrorMessages.EndDateAfterStartDate)
+  ),
   crop: yup.string().required(),
   cropType: yup.string().required(),
   requirements: yup.string().required(),
-  principalInvestigator: investigatorSchema,
+  principalInvestigator: yup.lazy((value) =>
+    // investigatorSchema.required() didn't work, but this seems to do the trick
+    value ? investigatorSchema : yup.object().required(ErrorMessages.PIRequired)
+  ),
   files: yup.array().of(fileSchema),
 });
 

--- a/Harvest.Web/ClientApp/src/schemas.ts
+++ b/Harvest.Web/ClientApp/src/schemas.ts
@@ -70,12 +70,19 @@ export const workItemSchema: SchemaOf<WorkItem> = yup.object().shape({
   quantity: yup
     .number()
     .required()
-    .typeError(ErrorMessages.WorkItemUnit)
-    .positive(ErrorMessages.WorkItemUnit)
-    .test(
-      "maxDigitsAfterDecimal",
-      ErrorMessages.WorkItemQuantityDecimalPlaces,
-      (number) => Number.isInteger((number || 0) * 10 ** 2)
+    .when(
+      // only validate when user has selected a labor/equipment/other option
+      "rateId",
+      (rateId, yup) =>
+        rateId &&
+        yup
+          .typeError(ErrorMessages.WorkItemUnit)
+          .positive(ErrorMessages.WorkItemUnit)
+          .test(
+            "maxDigitsAfterDecimal",
+            ErrorMessages.WorkItemQuantityDecimalPlaces,
+            (number: number) => Number.isInteger((number || 0) * 10 ** 2)
+          )
     ),
   unit: yup.string().defined(),
   markup: yup.boolean().defined(),

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -301,8 +301,8 @@ export interface TicketMessage {
 
 export interface RequestInput {
   id: number;
-  start: string;
-  end: string;
+  start: Date;
+  end: Date;
   crop: string;
   cropType: string;
   requirements?: string;


### PR DESCRIPTION
`<InputErrorMessage />` now displays multiple errors, each in its own `<p/>`.
Added a `validateAll`, which will validate only inputs that have a corresponding `<InputErrorMessage />`.

Wasn't sure about storing validate callbacks in a ref. I guess I could have stored in context state a validateAllCount/setValidateAllCount, increment it each time `validateAll` is called, and use an effect on that to trigger validations in each hook instance. Doesn't seem much prettier than refs, but I can do it if you think it would be easier to follow.

I don't know why the RequestContainer diff is so large. I didn't change THAT much. Maybe to do with resolving conflicts while rebasing?