### PR TITLE
replace <a> with react router's <Link> element

### DIFF
--- a/Harvest.Web/ClientApp/src/Invoices/InvoiceTable.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/InvoiceTable.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { Link } from "react-router-dom";
 import { Cell, Column, TableState } from "react-table";
 import { ReactTable } from "../Shared/ReactTable";
 import { ReactTableUtil } from "../Shared/TableUtil";
@@ -16,9 +17,9 @@ export const InvoiceTable = (props: Props) => {
       {
         Cell: (data: Cell<Invoice>) => (
           <div>
-            <a href={`/invoice/details/${data.row.original.projectId}/${data.row.original.id}`}>
+            <Link to={`/invoice/details/${data.row.original.projectId}/${data.row.original.id}`}>
               #{data.row.original.id}
-            </a>
+            </Link>
           </div>
         ),
         Header: " ",


### PR DESCRIPTION
resolve #564 
replace `<a>` with react router's `<Link>` element