### PR TITLE
Jcs/rate object code

### DIFF
--- a/Harvest.Core/Data/DbInitializer.cs
+++ b/Harvest.Core/Data/DbInitializer.cs
@@ -646,7 +646,7 @@ namespace Harvest.Core.Data
             rate.Type = Rate.Types.Other;
             rate.Description = "Century Project Soil Sample";
             rate.BillingUnit = "Russell Ranch";
-            rate.Account = "3-RRCNTRY";
+            rate.Account = "3-RRACRES-CNTRY";
             rate.Price = 70.00m;
             rate.Unit = "Per sample";
             rate.ExpenseObjectCode = "RAS5";
@@ -749,7 +749,7 @@ namespace Harvest.Core.Data
             rate.Type = Rate.Types.Labor;
             rate.Description = "Century Project Skilled Labor";
             rate.BillingUnit = "Russell Ranch";
-            rate.Account = "3-RRCNTRY";
+            rate.Account = "3-RRACRES-CNTRY";
             rate.Price = 91.00m;
             rate.Unit = "Hourly";
             rate.ExpenseObjectCode = "RAS5";
@@ -760,7 +760,7 @@ namespace Harvest.Core.Data
             rate.Type = Rate.Types.Labor;
             rate.Description = "Century Project Mechanic";
             rate.BillingUnit = "Russell Ranch";
-            rate.Account = "3-RRCNTRY";
+            rate.Account = "3-RRACRES-CNTRY";
             rate.Price = 92.00m;
             rate.Unit = "Hourly";
             rate.ExpenseObjectCode = "RAS5";
@@ -895,7 +895,7 @@ namespace Harvest.Core.Data
             rate.Type = Rate.Types.Acreage;
             rate.Description = "Century Project";
             rate.BillingUnit = "Russell Ranch";
-            rate.Account = "3-RRCNTRY";
+            rate.Account = "3-RRACRES-CNTRY";
             rate.Price = 3281.00m;
             rate.Unit = "Acre per Year";
             rate.ExpenseObjectCode = "RAS5";

--- a/Harvest.Core/Data/DbInitializer.cs
+++ b/Harvest.Core/Data/DbInitializer.cs
@@ -68,15 +68,7 @@ namespace Harvest.Core.Data
                 LastName = "Doval",
                 Iam = "1000050298"
             };
-            await CheckOrCreatePermission(systemRole, user);
-            user = new User
-            {
-                Email = "bmwong@ucdavis.edu",
-                Kerberos = "wongband",
-                FirstName = "Bryan",
-                LastName = "Wong",
-                Iam = "1000274724"
-            };
+
             await CheckOrCreatePermission(systemRole, user);
             await _dbContext.SaveChangesAsync();
 
@@ -148,6 +140,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFDS";
             rate.Price = 34.91m;
             rate.Unit = "Per Acre";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -158,6 +151,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFDS";
             rate.Price = 132.01m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -168,6 +162,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFDS";
             rate.Price = 34.44m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -178,6 +173,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFDS";
             rate.Price = 14.11m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -188,6 +184,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFDS";
             rate.Price = 90.02m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -198,6 +195,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFDS";
             rate.Price = 16.67m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -208,6 +206,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 685.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -218,6 +217,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 385.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -228,6 +228,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 1250.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -238,6 +239,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 50.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -248,6 +250,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 50.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -258,6 +261,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 25.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -268,6 +272,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 250.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -278,6 +283,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 190.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -288,6 +294,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 25.00m;
             rate.Unit = "Per Acre";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -298,6 +305,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 25.00m;
             rate.Unit = "Per Acre";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -308,6 +316,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 20.00m;
             rate.Unit = "Per Gallon";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -318,6 +327,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 90.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -328,6 +338,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 90.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -338,6 +349,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 14.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -348,6 +360,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 75.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -358,6 +371,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 50.00m;
             rate.Unit = "Per Acre";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -368,6 +382,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 500.00m;
             rate.Unit = "Each";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -378,6 +393,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 125.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -388,6 +404,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 55.00m;
             rate.Unit = "Per Acre";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -398,6 +415,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 16.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -408,6 +426,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 57.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -418,6 +437,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 76.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -428,6 +448,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 18.00m;
             rate.Unit = "Per Acre";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -438,6 +459,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 35.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -448,6 +470,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 65.00m;
             rate.Unit = "Per Acre";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -458,6 +481,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 132.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -468,6 +492,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 114.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -478,6 +503,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 34.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -488,6 +514,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 16.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -498,6 +525,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 427.00m;
             rate.Unit = "Per Month";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -508,6 +536,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 105.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -518,6 +547,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 63.00m;
             rate.Unit = "Daily";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -528,6 +558,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 30.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -538,6 +569,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 15.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -548,6 +580,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 65.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -558,6 +591,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-FRMRATE";
             rate.Price = 184.00m;
             rate.Unit = "Per Strip Weighed";
+            rate.ExpenseObjectCode = "RAY9";
 
             await _dbContext.Rates.AddAsync(rate);
         }
@@ -571,6 +605,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLV";
             rate.Price = 66.67m;
             rate.Unit = "Per acre";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -581,6 +616,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLP";
             rate.Price = 66.67m;
             rate.Unit = "Per acre";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -591,6 +627,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLE";
             rate.Price = 66.67m;
             rate.Unit = "Per acre";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -601,6 +638,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLW";
             rate.Price = 66.67m;
             rate.Unit = "Per acre";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -611,6 +649,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRCNTRY";
             rate.Price = 70.00m;
             rate.Unit = "Per sample";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -621,6 +660,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRBARN1";
             rate.Price = 1200.00m;
             rate.Unit = "Per event";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -631,6 +671,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRBARN1";
             rate.Price = 1605.00m;
             rate.Unit = "Per event";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -641,6 +682,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRBARN1";
             rate.Price = 600.00m;
             rate.Unit = "Per 1/2 day";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -651,6 +693,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRBARN1";
             rate.Price = 803.00m;
             rate.Unit = "Per 1/2 day";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -661,6 +704,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRBARN1";
             rate.Price = 1000.00m;
             rate.Unit = "Per day";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -671,6 +715,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRBARN1";
             rate.Price = 1337.00m;
             rate.Unit = "Per day";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
         }
@@ -685,6 +730,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRACRES";
             rate.Price = 60.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -695,6 +741,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRMSHOP";
             rate.Price = 72.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -705,6 +752,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRCNTRY";
             rate.Price = 91.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -715,6 +763,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRCNTRY";
             rate.Price = 92.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -725,6 +774,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFSA";
             rate.Price = 34.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -735,6 +785,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLV";
             rate.Price = 60.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -745,6 +796,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLP";
             rate.Price = 60.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -755,6 +807,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLE";
             rate.Price = 60.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -765,6 +818,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLW";
             rate.Price = 60.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -775,6 +829,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLV";
             rate.Price = 50.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -785,6 +840,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLP";
             rate.Price = 50.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -795,6 +851,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLE";
             rate.Price = 50.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -805,6 +862,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLW";
             rate.Price = 50.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -815,6 +873,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFDS";
             rate.Price = 72.00m;
             rate.Unit = "Hourly";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
         }
@@ -828,6 +887,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRACRES";
             rate.Price = 1150.00m;
             rate.Unit = "Acre per Year";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -838,6 +898,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-RRCNTRY";
             rate.Price = 3281.00m;
             rate.Unit = "Acre per Year";
+            rate.ExpenseObjectCode = "RAS5";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -848,6 +909,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLV";
             rate.Price = 1150.00m;
             rate.Unit = "Acre per Year";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -858,6 +920,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLP";
             rate.Price = 1150.00m;
             rate.Unit = "Acre per Year";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
 
@@ -868,6 +931,7 @@ namespace Harvest.Core.Data
             rate.Account = "3-APSNFLW";
             rate.Price = 1150.00m;
             rate.Unit = "Acre per Year";
+            rate.ExpenseObjectCode = "RAPB";
 
             await _dbContext.Rates.AddAsync(rate);
         }

--- a/Harvest.Core/Domain/Expense.cs
+++ b/Harvest.Core/Domain/Expense.cs
@@ -59,6 +59,7 @@ namespace Harvest.Core.Domain
         [StringLength(50)]
         public string Account { get; set; }
 
+        //This is actually required, but that will make the migration a pain...
         public string ExpenseObjectCode { get; set; }
 
         internal static void OnModelCreating(ModelBuilder modelBuilder)

--- a/Harvest.Core/Domain/Expense.cs
+++ b/Harvest.Core/Domain/Expense.cs
@@ -60,6 +60,7 @@ namespace Harvest.Core.Domain
         public string Account { get; set; }
 
         //This is actually required, but that will make the migration a pain...
+        [StringLength(5)]
         public string ExpenseObjectCode { get; set; }
 
         internal static void OnModelCreating(ModelBuilder modelBuilder)

--- a/Harvest.Core/Domain/Expense.cs
+++ b/Harvest.Core/Domain/Expense.cs
@@ -59,6 +59,8 @@ namespace Harvest.Core.Domain
         [StringLength(50)]
         public string Account { get; set; }
 
+        public string ExpenseObjectCode { get; set; }
+
         internal static void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Expense>().HasIndex(a => a.ProjectId);

--- a/Harvest.Core/Domain/Rate.cs
+++ b/Harvest.Core/Domain/Rate.cs
@@ -59,6 +59,10 @@ namespace Harvest.Core.Domain
         [Display(Name = "Pass Through")]
         public bool IsPassthrough { get; set; } = false;
 
+        [Display(Name = "Expense Object Code")]
+        [StringLength(5)]
+        public string ExpenseObjectCode { get; set; }
+
         // projects using this rate
         [JsonIgnore]
         public List<Project> Projects { get; set; }

--- a/Harvest.Core/Migrations/SqlServer/20211005165614_ExpenseObjectCode.Designer.cs
+++ b/Harvest.Core/Migrations/SqlServer/20211005165614_ExpenseObjectCode.Designer.cs
@@ -3,46 +3,52 @@ using System;
 using Harvest.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
-namespace Harvest.Core.Migrations.Sqlite
+namespace Harvest.Core.Migrations.SqlServer
 {
-    [DbContext(typeof(AppDbContextSqlite))]
-    partial class AppDbContextSqliteModelSnapshot : ModelSnapshot
+    [DbContext(typeof(AppDbContextSqlServer))]
+    [Migration("20211005165614_ExpenseObjectCode")]
+    partial class ExpenseObjectCode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "5.0.10");
+                .HasAnnotation("Relational:MaxIdentifierLength", 128)
+                .HasAnnotation("ProductVersion", "5.0.10")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
             modelBuilder.Entity("Harvest.Core.Domain.Account", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int?>("ApprovedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("ApprovedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("Number")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<decimal>("Percentage")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -61,17 +67,18 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -86,19 +93,20 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Identifier")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("QuoteId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -114,67 +122,68 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Account")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Activity")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<bool>("Approved")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<int?>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<string>("ExpenseObjectCode")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("InvoiceId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("IsPassthrough")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<bool>("Markup")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<decimal>("Price")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("Quantity")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("RateId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(15)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(15)");
 
                     b.HasKey("Id");
 
@@ -193,22 +202,23 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Crop")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Details")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<Polygon>("Location")
-                        .HasColumnType("POLYGON");
+                        .HasColumnType("geography");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -223,31 +233,32 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("KfsTrackingNumber")
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("SlothTransactionId")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Status")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.HasKey("Id");
 
@@ -260,27 +271,28 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Body")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("Sent")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Subject")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.HasKey("Id");
 
@@ -293,13 +305,14 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int>("RoleId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("UserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -314,73 +327,74 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int?>("AcreageRateId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<double>("Acres")
-                        .HasColumnType("REAL");
+                        .HasColumnType("float");
 
                     b.Property<decimal>("ChargedTotal")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Crop")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(512)");
 
                     b.Property<string>("CropType")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("CurrentAccountVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("End")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<int?>("OriginalProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("PrincipalInvestigatorId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int?>("QuoteId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("QuoteTotal")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Requirements")
                         .IsRequired()
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(max)")
                         .HasDefaultValue("N/A");
 
                     b.Property<DateTime>("Start")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -405,33 +419,34 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ContentType")
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("FileName")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<int>("FileSize")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Identifier")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -448,26 +463,27 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Action")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<DateTime>("ActionDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("ActorId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Details")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -482,43 +498,45 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int?>("ApprovedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("ApprovedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("CurrentDocumentId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("InitiatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Text")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("ApprovedById");
 
                     b.HasIndex("CurrentDocumentId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[CurrentDocumentId] IS NOT NULL");
 
                     b.HasIndex("InitiatedById");
 
@@ -531,61 +549,62 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Account")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("BillingUnit")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<DateTime?>("EffectiveOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ExpenseObjectCode")
                         .HasMaxLength(5)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(5)");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsPassthrough")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<decimal>("Price")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(15)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(15)");
 
                     b.Property<string>("Unit")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("UpdatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("UpdatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 
@@ -604,12 +623,13 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -623,48 +643,49 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<bool>("Completed")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("DueDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("InvoiceId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Requirements")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(25)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(25)");
 
                     b.Property<int?>("UpdatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("UpdatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("WorkNotes")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 
@@ -691,33 +712,34 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ContentType")
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("FileName")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<int>("FileSize")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Identifier")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("TicketId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -734,20 +756,21 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Message")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("TicketId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -764,24 +787,25 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Account")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("InvoiceId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(10)");
 
                     b.HasKey("Id");
 
@@ -794,30 +818,31 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.Property<string>("FirstName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Iam")
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(10)");
 
                     b.Property<string>("Kerberos")
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.Property<string>("LastName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 

--- a/Harvest.Core/Migrations/SqlServer/20211005165614_ExpenseObjectCode.cs
+++ b/Harvest.Core/Migrations/SqlServer/20211005165614_ExpenseObjectCode.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Harvest.Core.Migrations.SqlServer
+{
+    public partial class ExpenseObjectCode : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExpenseObjectCode",
+                table: "Rates",
+                type: "nvarchar(5)",
+                maxLength: 5,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExpenseObjectCode",
+                table: "Expenses",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExpenseObjectCode",
+                table: "Rates");
+
+            migrationBuilder.DropColumn(
+                name: "ExpenseObjectCode",
+                table: "Expenses");
+        }
+    }
+}

--- a/Harvest.Core/Migrations/SqlServer/20211005170213_ExpenseObjectCode2.Designer.cs
+++ b/Harvest.Core/Migrations/SqlServer/20211005170213_ExpenseObjectCode2.Designer.cs
@@ -3,46 +3,52 @@ using System;
 using Harvest.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
-namespace Harvest.Core.Migrations.Sqlite
+namespace Harvest.Core.Migrations.SqlServer
 {
-    [DbContext(typeof(AppDbContextSqlite))]
-    partial class AppDbContextSqliteModelSnapshot : ModelSnapshot
+    [DbContext(typeof(AppDbContextSqlServer))]
+    [Migration("20211005170213_ExpenseObjectCode2")]
+    partial class ExpenseObjectCode2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "5.0.10");
+                .HasAnnotation("Relational:MaxIdentifierLength", 128)
+                .HasAnnotation("ProductVersion", "5.0.10")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
             modelBuilder.Entity("Harvest.Core.Domain.Account", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int?>("ApprovedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("ApprovedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("Number")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<decimal>("Percentage")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -61,17 +67,18 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -86,19 +93,20 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Identifier")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("QuoteId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -114,68 +122,69 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Account")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Activity")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<bool>("Approved")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<int?>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<string>("ExpenseObjectCode")
                         .HasMaxLength(5)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(5)");
 
                     b.Property<int?>("InvoiceId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("IsPassthrough")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<bool>("Markup")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<decimal>("Price")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("Quantity")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("RateId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(15)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(15)");
 
                     b.HasKey("Id");
 
@@ -194,22 +203,23 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Crop")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Details")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<Polygon>("Location")
-                        .HasColumnType("POLYGON");
+                        .HasColumnType("geography");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -224,31 +234,32 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("KfsTrackingNumber")
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("SlothTransactionId")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Status")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.HasKey("Id");
 
@@ -261,27 +272,28 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Body")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("Sent")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Subject")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.HasKey("Id");
 
@@ -294,13 +306,14 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int>("RoleId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("UserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -315,73 +328,74 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int?>("AcreageRateId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<double>("Acres")
-                        .HasColumnType("REAL");
+                        .HasColumnType("float");
 
                     b.Property<decimal>("ChargedTotal")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Crop")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(512)");
 
                     b.Property<string>("CropType")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("CurrentAccountVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("End")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<int?>("OriginalProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("PrincipalInvestigatorId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int?>("QuoteId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("QuoteTotal")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Requirements")
                         .IsRequired()
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(max)")
                         .HasDefaultValue("N/A");
 
                     b.Property<DateTime>("Start")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -406,33 +420,34 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ContentType")
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("FileName")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<int>("FileSize")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Identifier")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -449,26 +464,27 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Action")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<DateTime>("ActionDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("ActorId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Details")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -483,43 +499,45 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int?>("ApprovedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("ApprovedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("CurrentDocumentId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("InitiatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Text")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("ApprovedById");
 
                     b.HasIndex("CurrentDocumentId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[CurrentDocumentId] IS NOT NULL");
 
                     b.HasIndex("InitiatedById");
 
@@ -532,61 +550,62 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Account")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("BillingUnit")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<DateTime?>("EffectiveOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ExpenseObjectCode")
                         .HasMaxLength(5)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(5)");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsPassthrough")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<decimal>("Price")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(15)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(15)");
 
                     b.Property<string>("Unit")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("UpdatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("UpdatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 
@@ -605,12 +624,13 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -624,48 +644,49 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<bool>("Completed")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("DueDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("InvoiceId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Requirements")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(25)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(25)");
 
                     b.Property<int?>("UpdatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("UpdatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("WorkNotes")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 
@@ -692,33 +713,34 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ContentType")
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("FileName")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<int>("FileSize")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Identifier")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("TicketId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -735,20 +757,21 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Message")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("TicketId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -765,24 +788,25 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Account")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("InvoiceId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<decimal>("Total")
                         .HasPrecision(18, 2)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(10)");
 
                     b.HasKey("Id");
 
@@ -795,30 +819,31 @@ namespace Harvest.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.Property<string>("FirstName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Iam")
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(10)");
 
                     b.Property<string>("Kerberos")
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.Property<string>("LastName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 

--- a/Harvest.Core/Migrations/SqlServer/20211005170213_ExpenseObjectCode2.cs
+++ b/Harvest.Core/Migrations/SqlServer/20211005170213_ExpenseObjectCode2.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Harvest.Core.Migrations.SqlServer
+{
+    public partial class ExpenseObjectCode2 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ExpenseObjectCode",
+                table: "Expenses",
+                type: "nvarchar(5)",
+                maxLength: 5,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ExpenseObjectCode",
+                table: "Expenses",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(5)",
+                oldMaxLength: 5,
+                oldNullable: true);
+        }
+    }
+}

--- a/Harvest.Core/Migrations/SqlServer/AppDbContextSqlServerModelSnapshot.cs
+++ b/Harvest.Core/Migrations/SqlServer/AppDbContextSqlServerModelSnapshot.cs
@@ -146,6 +146,9 @@ namespace Harvest.Core.Migrations.SqlServer
                         .HasMaxLength(250)
                         .HasColumnType("nvarchar(250)");
 
+                    b.Property<string>("ExpenseObjectCode")
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<int?>("InvoiceId")
                         .HasColumnType("int");
 
@@ -569,6 +572,10 @@ namespace Harvest.Core.Migrations.SqlServer
 
                     b.Property<DateTime?>("EffectiveOn")
                         .HasColumnType("datetime2");
+
+                    b.Property<string>("ExpenseObjectCode")
+                        .HasMaxLength(5)
+                        .HasColumnType("nvarchar(5)");
 
                     b.Property<bool>("IsActive")
                         .HasColumnType("bit");

--- a/Harvest.Core/Migrations/SqlServer/AppDbContextSqlServerModelSnapshot.cs
+++ b/Harvest.Core/Migrations/SqlServer/AppDbContextSqlServerModelSnapshot.cs
@@ -147,7 +147,8 @@ namespace Harvest.Core.Migrations.SqlServer
                         .HasColumnType("nvarchar(250)");
 
                     b.Property<string>("ExpenseObjectCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(5)
+                        .HasColumnType("nvarchar(5)");
 
                     b.Property<int?>("InvoiceId")
                         .HasColumnType("int");

--- a/Harvest.Core/Migrations/Sqlite/20211005165605_ExpenseObjectCode.Designer.cs
+++ b/Harvest.Core/Migrations/Sqlite/20211005165605_ExpenseObjectCode.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Harvest.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
 namespace Harvest.Core.Migrations.Sqlite
 {
     [DbContext(typeof(AppDbContextSqlite))]
-    partial class AppDbContextSqliteModelSnapshot : ModelSnapshot
+    [Migration("20211005165605_ExpenseObjectCode")]
+    partial class ExpenseObjectCode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Harvest.Core/Migrations/Sqlite/20211005165605_ExpenseObjectCode.cs
+++ b/Harvest.Core/Migrations/Sqlite/20211005165605_ExpenseObjectCode.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Harvest.Core.Migrations.Sqlite
+{
+    public partial class ExpenseObjectCode : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExpenseObjectCode",
+                table: "Rates",
+                type: "TEXT",
+                maxLength: 5,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExpenseObjectCode",
+                table: "Expenses",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExpenseObjectCode",
+                table: "Rates");
+
+            migrationBuilder.DropColumn(
+                name: "ExpenseObjectCode",
+                table: "Expenses");
+        }
+    }
+}

--- a/Harvest.Core/Migrations/Sqlite/20211005170202_ExpenseObjectCode2.Designer.cs
+++ b/Harvest.Core/Migrations/Sqlite/20211005170202_ExpenseObjectCode2.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Harvest.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
 namespace Harvest.Core.Migrations.Sqlite
 {
     [DbContext(typeof(AppDbContextSqlite))]
-    partial class AppDbContextSqliteModelSnapshot : ModelSnapshot
+    [Migration("20211005170202_ExpenseObjectCode2")]
+    partial class ExpenseObjectCode2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Harvest.Core/Migrations/Sqlite/20211005170202_ExpenseObjectCode2.cs
+++ b/Harvest.Core/Migrations/Sqlite/20211005170202_ExpenseObjectCode2.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Harvest.Core.Migrations.Sqlite
+{
+    public partial class ExpenseObjectCode2 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Harvest.Core/Services/ExpenseService.cs
+++ b/Harvest.Core/Services/ExpenseService.cs
@@ -87,17 +87,18 @@ namespace Harvest.Core.Services
 
             var expense = new Expense
             {
-                Type = project.AcreageRate.Type,
-                Description = project.AcreageRate.Description,
-                Price = project.AcreageRate.Price / 12, //This can be more than 2 decimals
-                Quantity = (decimal) project.Acres,
-                Total = Math.Round(amountToCharge,2, MidpointRounding.ToZero),
-                ProjectId = project.Id,
-                RateId = project.AcreageRate.Id,
-                InvoiceId = null,
-                CreatedOn = DateTime.UtcNow,
-                CreatedBy = user,
-                Account = project.AcreageRate.Account,
+                Type              = project.AcreageRate.Type,
+                Description       = project.AcreageRate.Description,
+                Price             = project.AcreageRate.Price / 12, //This can be more than 2 decimals
+                Quantity          = (decimal) project.Acres,
+                Total             = Math.Round(amountToCharge,2, MidpointRounding.ToZero),
+                ProjectId         = project.Id,
+                RateId            = project.AcreageRate.Id,
+                InvoiceId         = null,
+                CreatedOn         = DateTime.UtcNow,
+                CreatedBy         = user,
+                Account           = project.AcreageRate.Account,
+                ExpenseObjectCode = project.AcreageRate.ExpenseObjectCode,
             };
             return expense;
         }

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -48,12 +48,13 @@ namespace Harvest.Web.Controllers.Api
             var allRates = await _dbContext.Rates.Where(a => a.IsActive).ToListAsync();
             foreach (var expense in expenses)
             {
-                expense.CreatedBy     = user;
-                expense.CreatedOn     = DateTime.UtcNow;
-                expense.ProjectId     = projectId;
-                expense.InvoiceId     = null;
-                expense.Account       = allRates.Single(a => a.Id == expense.RateId).Account;
-                expense.IsPassthrough = allRates.Single(a => a.Id == expense.RateId).IsPassthrough;
+                expense.CreatedBy         = user;
+                expense.CreatedOn         = DateTime.UtcNow;
+                expense.ProjectId         = projectId;
+                expense.InvoiceId         = null;
+                expense.Account           = allRates.Single(a => a.Id == expense.RateId).Account;
+                expense.IsPassthrough     = allRates.Single(a => a.Id == expense.RateId).IsPassthrough;
+                expense.ExpenseObjectCode = allRates.Single(a => a.Id == expense.RateId).ExpenseObjectCode;
             }
 
             _dbContext.Expenses.AddRange(expenses);

--- a/Harvest.Web/Controllers/RateController.cs
+++ b/Harvest.Web/Controllers/RateController.cs
@@ -90,6 +90,28 @@ namespace Harvest.Web.Controllers
                 ModelState.AddModelError("Rate.IsPassthrough", errorMessage: "Passthrough can only be checked for Other types.");
             }
 
+            if (!model.Rate.IsPassthrough)
+            {
+                if (string.IsNullOrWhiteSpace(model.Rate.ExpenseObjectCode))
+                {
+                    ModelState.AddModelError("Rate.ExpenseObjectCode", errorMessage: "Expense Object Code is required.");
+                }
+                else
+                {
+                    if (accountValidation.IsValid &&
+                        !(await _financialService.IsObjectValid(accountValidation.KfsAccount.ChartOfAccountsCode,
+                            model.Rate.ExpenseObjectCode)))
+                    {
+                        ModelState.AddModelError("Rate.ExpenseObjectCode", errorMessage: "Expense Object Code is invalid.");
+                    }
+                }
+            }
+            else
+            {
+                model.Rate.ExpenseObjectCode = "80RS";
+            }
+
+
             if (!ModelState.IsValid)
             {
                 ErrorMessage = "There are validation errors, please correct them and try again.";
@@ -154,6 +176,27 @@ namespace Harvest.Web.Controllers
                 ModelState.AddModelError("Rate.IsPassthrough", errorMessage: "Passthrough can only be checked for Other types.");
             }
 
+            if (!model.Rate.IsPassthrough)
+            {
+                if (string.IsNullOrWhiteSpace(model.Rate.ExpenseObjectCode))
+                {
+                    ModelState.AddModelError("Rate.ExpenseObjectCode", errorMessage: "Expense Object Code is required.");
+                }
+                else
+                {
+                    if (accountValidation.IsValid &&
+                        !(await _financialService.IsObjectValid(accountValidation.KfsAccount.ChartOfAccountsCode,
+                            model.Rate.ExpenseObjectCode)))
+                    {
+                        ModelState.AddModelError("Rate.ExpenseObjectCode", errorMessage: "Expense Object Code is invalid.");
+                    }
+                }
+            }
+            else
+            {
+                model.Rate.ExpenseObjectCode = "80RS"; //Config setting?
+            }
+
             if (!ModelState.IsValid)
             {
                 ErrorMessage = "There are validation errors, please correct them and try again.";
@@ -182,16 +225,17 @@ namespace Harvest.Web.Controllers
 
         private static void UpdateCommonValues(RateEditModel model, Rate destinationRate, AccountValidationModel accountValidation, User user)
         {
-            destinationRate.Account       = accountValidation.KfsAccount.ToString(); 
-            destinationRate.BillingUnit   = model.Rate.BillingUnit;
-            destinationRate.Description   = model.Rate.Description;
-            destinationRate.EffectiveOn   = model.Rate.EffectiveOn.FromPacificTime();
-            destinationRate.Price         = model.Rate.Price; 
-            destinationRate.Type          = model.Rate.Type;
-            destinationRate.Unit          = model.Rate.Unit;
-            destinationRate.UpdatedOn     = DateTime.UtcNow;
-            destinationRate.UpdatedBy     = user;
-            destinationRate.IsPassthrough = model.Rate.Type == Rate.Types.Other && model.Rate.IsPassthrough;
+            destinationRate.Account           = accountValidation.KfsAccount.ToString(); 
+            destinationRate.BillingUnit       = model.Rate.BillingUnit;
+            destinationRate.Description       = model.Rate.Description;
+            destinationRate.EffectiveOn       = model.Rate.EffectiveOn.FromPacificTime();
+            destinationRate.Price             = model.Rate.Price; 
+            destinationRate.Type              = model.Rate.Type;
+            destinationRate.Unit              = model.Rate.Unit;
+            destinationRate.UpdatedOn         = DateTime.UtcNow;
+            destinationRate.UpdatedBy         = user;
+            destinationRate.IsPassthrough     = model.Rate.Type == Rate.Types.Other && model.Rate.IsPassthrough;
+            destinationRate.ExpenseObjectCode = model.Rate.ExpenseObjectCode.Trim().ToUpper();
         }
 
         // GET: RateController/Delete/5

--- a/Harvest.Web/Views/Rate/_RateDetails.cshtml
+++ b/Harvest.Web/Views/Rate/_RateDetails.cshtml
@@ -77,6 +77,12 @@
     <dd class="col-sm-10">
         @Html.DisplayFor(model => model.Rate.Account)
     </dd>
+    <dt class="col-sm-2">
+        @Html.DisplayNameFor(model => model.Rate.ExpenseObjectCode)
+    </dt>
+    <dd class="col-sm-10">
+        @Html.DisplayFor(model => model.Rate.ExpenseObjectCode)
+    </dd>
     @if (Model.AccountValidation.IsValid)
     {
         <dt class="col-sm-2">

--- a/Harvest.Web/Views/Rate/_RateForm.cshtml
+++ b/Harvest.Web/Views/Rate/_RateForm.cshtml
@@ -31,6 +31,11 @@
     <span asp-validation-for="Rate.Account" class="text-danger"></span>
 </div>
 <div class="form-group">
+    <label asp-for="Rate.ExpenseObjectCode" class="control-label"></label>
+    <input asp-for="Rate.ExpenseObjectCode" class="form-control" />
+    <span asp-validation-for="Rate.ExpenseObjectCode" class="text-danger"></span>
+</div>
+<div class="form-group">
     <label asp-for="Rate.Price" class="control-label"></label>
     <input asp-for="Rate.Price" class="form-control" />
     <span asp-validation-for="Rate.Price" class="text-danger"></span>


### PR DESCRIPTION
I don't know that we want to go this way.
Another way we could do it is change the billing unit to a dropdown then base the object code off of RR, PLS, or CAES. And PassThrough will have separate values

If we do this, we should reset the DB after deployment. Also, manually set the see value to invoices to 1000 in test to avoid future sloth duplicates