### PR TITLE
Move API calls to /api namespace, default react otherwise

### DIFF
--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Route } from "react-router-dom";
+import { Route, Switch, useLocation } from "react-router-dom";
 import { Toaster } from "react-hot-toast";
 import { ModalProvider } from "react-modal-hook";
 
@@ -35,105 +35,122 @@ function App() {
     <AppContext.Provider value={Harvest}>
       <ModalProvider>
         <Toaster />
-        <Route exact path="/" component={HomeContainer} />
-        <Route
-          exact
-          path="/request/create/:projectId?"
-          component={RequestContainer}
-        />
-        <ConditionalRoute
-          roles={["PI"]}
-          path="/request/approve/:projectId"
-          component={ApprovalContainer}
-        />
-        <ConditionalRoute
-          roles={["PI"]}
-          path="/request/changeAccount/:projectId"
-          component={AccountChangeContainer}
-        />
-        <Route
-          path="/project/invoices/:projectId"
-          component={InvoiceListContainer}
-        />
-        <ConditionalRoute
-          roles={["FieldManager", "PI"]}
-          path="/invoice/details/:projectId/:invoiceId"
-          component={InvoiceDetailContainer}
-        />
-        <ConditionalRoute
-          roles={["FieldManager", "Supervisor"]}
-          path="/quote/create/:projectId"
-          component={QuoteContainer}
-        />
-        <ConditionalRoute
-          roles={["PI"]}
-          path="/quote/details/:projectId"
-          component={QuoteDisplayContainer}
-        />
-        <ConditionalRoute
-          roles={["FieldManager"]}
-          path="/project/closeout/:projectId"
-          component={CloseoutContainer}
-        />
-        <ConditionalRoute
-          exact
-          roles={["FieldManager", "Supervisor"]}
-          path="/project"
-        >
-          <ProjectListContainer projectSource="/api/Project/All" />
-        </ConditionalRoute>
-        <ConditionalRoute
-          exact
-          roles={["FieldManager", "Supervisor"]}
-          path="/project/needsAttention"
-        >
-          <ProjectListContainer projectSource="/api/Project/RequiringManagerAttention" />
-        </ConditionalRoute>
-        <ConditionalRoute exact roles={["PI"]} path="/project/mine">
-          <ProjectListContainer projectSource="/api/Project/GetMine" />
-        </ConditionalRoute>
-        <ConditionalRoute
-          roles={["FieldManager", "Supervisor", "PI"]}
-          path="/ticket/create/:projectId"
-          component={TicketCreate}
-        />
-        <ConditionalRoute
-          exact
-          roles={["FieldManager", "Supervisor"]}
-          path="/ticket/needsAttention"
-        >
-          <TicketListContainer projectSource="/api/ticket/RequiringManagerAttention" />
-        </ConditionalRoute>
-        <ConditionalRoute exact roles={["PI"]} path="/ticket/mine">
-          <TicketListContainer projectSource="/api/ticket/RequiringPIAttention" />
-        </ConditionalRoute>
-        <Route path="/ticket/list/:projectId" component={TicketsContainer} />
-        <Route
-          path="/ticket/details/:projectId/:ticketId"
-          component={TicketDetailContainer}
-        />
-        <Route
-          path="/project/details/:projectId"
-          component={ProjectDetailContainer}
-        />
-        <ConditionalRoute
-          roles={["FieldManager", "Supervisor", "Worker"]}
-          path="/expense/entry/:projectId?"
-          component={ExpenseEntryContainer}
-        />
-        <Route
-          path="/expense/unbilled/:projectId"
-          component={UnbilledExpensesContainer}
-        />
-        <ConditionalRoute
-          roles={["FieldManager", "Supervisor"]}
-          exact
-          path="/project/map"
-          component={ProjectFields}
-        />
+        <Switch>
+          <Route exact path="/" component={HomeContainer} />
+          <Route
+            exact
+            path="/request/create/:projectId?"
+            component={RequestContainer}
+          />
+          <ConditionalRoute
+            roles={["PI"]}
+            path="/request/approve/:projectId"
+            component={ApprovalContainer}
+          />
+          <ConditionalRoute
+            roles={["PI"]}
+            path="/request/changeAccount/:projectId"
+            component={AccountChangeContainer}
+          />
+          <Route
+            path="/project/invoices/:projectId"
+            component={InvoiceListContainer}
+          />
+          <ConditionalRoute
+            roles={["FieldManager", "PI"]}
+            path="/invoice/details/:projectId/:invoiceId"
+            component={InvoiceDetailContainer}
+          />
+          <ConditionalRoute
+            roles={["FieldManager", "Supervisor"]}
+            path="/quote/create/:projectId"
+            component={QuoteContainer}
+          />
+          <ConditionalRoute
+            roles={["PI"]}
+            path="/quote/details/:projectId"
+            component={QuoteDisplayContainer}
+          />
+          <ConditionalRoute
+            roles={["FieldManager"]}
+            path="/project/closeout/:projectId"
+            component={CloseoutContainer}
+          />
+          <ConditionalRoute
+            exact
+            roles={["FieldManager", "Supervisor"]}
+            path="/project"
+          >
+            <ProjectListContainer projectSource="/api/Project/All" />
+          </ConditionalRoute>
+          <ConditionalRoute
+            exact
+            roles={["FieldManager", "Supervisor"]}
+            path="/project/needsAttention"
+          >
+            <ProjectListContainer projectSource="/api/Project/RequiringManagerAttention" />
+          </ConditionalRoute>
+          <ConditionalRoute exact roles={["PI"]} path="/project/mine">
+            <ProjectListContainer projectSource="/api/Project/GetMine" />
+          </ConditionalRoute>
+          <ConditionalRoute
+            roles={["FieldManager", "Supervisor", "PI"]}
+            path="/ticket/create/:projectId"
+            component={TicketCreate}
+          />
+          <ConditionalRoute
+            exact
+            roles={["FieldManager", "Supervisor"]}
+            path="/ticket/needsAttention"
+          >
+            <TicketListContainer projectSource="/api/ticket/RequiringManagerAttention" />
+          </ConditionalRoute>
+          <ConditionalRoute exact roles={["PI"]} path="/ticket/mine">
+            <TicketListContainer projectSource="/api/ticket/RequiringPIAttention" />
+          </ConditionalRoute>
+          <Route path="/ticket/list/:projectId" component={TicketsContainer} />
+          <Route
+            path="/ticket/details/:projectId/:ticketId"
+            component={TicketDetailContainer}
+          />
+          <Route
+            path="/project/details/:projectId"
+            component={ProjectDetailContainer}
+          />
+          <ConditionalRoute
+            roles={["FieldManager", "Supervisor", "Worker"]}
+            path="/expense/entry/:projectId?"
+            component={ExpenseEntryContainer}
+          />
+          <Route
+            path="/expense/unbilled/:projectId"
+            component={UnbilledExpensesContainer}
+          />
+          <ConditionalRoute
+            roles={["FieldManager", "Supervisor"]}
+            exact
+            path="/project/map"
+            component={ProjectFields}
+          />
+          <Route path="*">
+            <NoMatch />
+          </Route>
+        </Switch>
       </ModalProvider>
     </AppContext.Provider>
   );
 }
+
+const NoMatch = () => {
+  let location = useLocation();
+
+  return (
+    <div>
+      <h3>
+        Page not found: <code>{location.pathname}</code>
+      </h3>
+    </div>
+  );
+};
 
 export default App;

--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -80,17 +80,17 @@ function App() {
           roles={["FieldManager", "Supervisor"]}
           path="/project"
         >
-          <ProjectListContainer projectSource="/Project/All" />
+          <ProjectListContainer projectSource="/api/Project/All" />
         </ConditionalRoute>
         <ConditionalRoute
           exact
           roles={["FieldManager", "Supervisor"]}
           path="/project/needsAttention"
         >
-          <ProjectListContainer projectSource="/Project/RequiringManagerAttention" />
+          <ProjectListContainer projectSource="/api/Project/RequiringManagerAttention" />
         </ConditionalRoute>
         <ConditionalRoute exact roles={["PI"]} path="/project/mine">
-          <ProjectListContainer projectSource="/Project/GetMine" />
+          <ProjectListContainer projectSource="/api/Project/GetMine" />
         </ConditionalRoute>
         <ConditionalRoute
           roles={["FieldManager", "Supervisor", "PI"]}
@@ -102,10 +102,10 @@ function App() {
           roles={["FieldManager", "Supervisor"]}
           path="/ticket/needsAttention"
         >
-          <TicketListContainer projectSource="/ticket/RequiringManagerAttention" />
+          <TicketListContainer projectSource="/api/ticket/RequiringManagerAttention" />
         </ConditionalRoute>
         <ConditionalRoute exact roles={["PI"]} path="/ticket/mine">
-          <TicketListContainer projectSource="/ticket/RequiringPIAttention" />
+          <TicketListContainer projectSource="/api/ticket/RequiringPIAttention" />
         </ConditionalRoute>
         <Route path="/ticket/list/:projectId" component={TicketsContainer} />
         <Route

--- a/Harvest.Web/ClientApp/src/Closeout/CloseoutContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Closeout/CloseoutContainer.tsx
@@ -34,7 +34,7 @@ export const CloseoutContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/Project/Get/${projectId}`);
+      const response = await fetch(`/api/Project/Get/${projectId}`);
       if (response.ok) {
         const proj: Project = await response.json();
         getIsMounted() && setProject(proj);
@@ -85,7 +85,7 @@ export const CloseoutContainer = () => {
       return;
     }
 
-    const request = fetch(`/Invoice/DoCloseout/${projectId}`, {
+    const request = fetch(`/api/Invoice/DoCloseout/${projectId}`, {
       method: "POST",
     });
 

--- a/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
@@ -67,7 +67,7 @@ export const ExpenseEntryContainer = () => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await fetch("/Rate/Active");
+      const response = await fetch("/api/Rate/Active");
 
       if (response.ok) {
         const rates: Rate[] = await response.json();
@@ -123,7 +123,7 @@ export const ExpenseEntryContainer = () => {
         )
     );
 
-    const request = fetch(`/Expense/Create/${projectId}`, {
+    const request = fetch(`/api/Expense/Create/${projectId}`, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/Harvest.Web/ClientApp/src/Expenses/ProjectSelection.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ProjectSelection.tsx
@@ -16,7 +16,7 @@ export const ProjectSelection = (props: Props) => {
   useEffect(() => {
     // get list of projects
     const cb = async () => {
-      const response = await fetch(`/Project/Active`);
+      const response = await fetch(`/api/Project/Active`);
 
       if (response.ok) {
         const projects = await response.json();

--- a/Harvest.Web/ClientApp/src/Expenses/UnbilledExpensesContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/UnbilledExpensesContainer.tsx
@@ -39,7 +39,7 @@ export const UnbilledExpensesContainer = (props: Props) => {
     if (projectId === undefined) return;
 
     const cb = async () => {
-      const response = await fetch(`/Expense/GetUnbilled/${projectId}`);
+      const response = await fetch(`/api/Expense/GetUnbilled/${projectId}`);
 
       if (response.ok) {
         const expenses: Expense[] = await response.json();
@@ -57,7 +57,7 @@ export const UnbilledExpensesContainer = (props: Props) => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await fetch(`/Project/Get/${projectId}`);
+      const response = await fetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const project = (await response.json()) as Project;
@@ -80,7 +80,7 @@ export const UnbilledExpensesContainer = (props: Props) => {
       return;
     }
 
-    const request = fetch(`/Expense/Delete?expenseId=${expense.id}`, {
+    const request = fetch(`/api/Expense/Delete?expenseId=${expense.id}`, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/Harvest.Web/ClientApp/src/Fields/FieldLayers.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldLayers.tsx
@@ -18,7 +18,7 @@ export const FieldLayers = (props: Props) => {
       const endDate = new Date(props.project.end);
 
       const activeFieldResponse = await fetch(
-        `/Field/Active?start=${startDate.toLocaleDateString()}&end=${endDate.toLocaleDateString()}`
+        `/api/Field/Active?start=${startDate.toLocaleDateString()}&end=${endDate.toLocaleDateString()}`
       );
 
       if (activeFieldResponse.ok) {

--- a/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
@@ -13,7 +13,7 @@ export const FieldManagerHome = () => {
   useEffect(() => {
     // get info on projects requiring approval
     const getProjects = async () => {
-      const response = await fetch("/project/RequiringManagerAttention");
+      const response = await fetch("/api/project/RequiringManagerAttention");
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);
@@ -25,7 +25,7 @@ export const FieldManagerHome = () => {
 
   useEffect(() => {
     const getTicketsWaitingForMe = async () => {
-      const response = await fetch("/ticket/RequiringManagerAttention?limit=3");
+      const response = await fetch("/api/ticket/RequiringManagerAttention?limit=3");
       if (getIsMounted()) {
         const tickets: Ticket[] = await response.json();
         getIsMounted() && setTickets(tickets);

--- a/Harvest.Web/ClientApp/src/Home/PIHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/PIHome.tsx
@@ -12,7 +12,7 @@ export const PIHome = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const getProjectsWaitingForMe = async () => {
-      const response = await fetch("/project/RequiringPIAttention");
+      const response = await fetch("/api/project/RequiringPIAttention");
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);
@@ -24,7 +24,7 @@ export const PIHome = () => {
 
   useEffect(() => {
     const getTicketsWaitingForMe = async () => {
-      const response = await fetch("/ticket/RequiringPIAttention?limit=3");
+      const response = await fetch("/api/ticket/RequiringPIAttention?limit=3");
       if (getIsMounted()) {
         const tickets: Ticket[] = await response.json();
         getIsMounted() && setTickets(tickets);

--- a/Harvest.Web/ClientApp/src/Home/SupervisorHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/SupervisorHome.tsx
@@ -12,7 +12,7 @@ export const SupervisorHome = () => {
   useEffect(() => {
     // get info on projects requiring approval
     const getProjects = async () => {
-      const response = await fetch("/project/RequiringManagerAttention");
+      const response = await fetch("/api/project/RequiringManagerAttention");
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);
@@ -24,7 +24,7 @@ export const SupervisorHome = () => {
 
   useEffect(() => {
     const getTicketsWaitingForMe = async () => {
-      const response = await fetch("/ticket/RequiringManagerAttention?limit=3");
+      const response = await fetch("/api/ticket/RequiringManagerAttention?limit=3");
       if (getIsMounted()) {
         const tickets: Ticket[] = await response.json();
         getIsMounted() && setTickets(tickets);

--- a/Harvest.Web/ClientApp/src/Home/WorkerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/WorkerHome.tsx
@@ -10,7 +10,7 @@ export const WorkerHome = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const getProjectsWithRecentExpenses = async () => {
-      const response = await fetch("/expense/GetRecentExpensedProjects");
+      const response = await fetch("/api/expense/GetRecentExpensedProjects");
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);

--- a/Harvest.Web/ClientApp/src/Invoices/InvoiceDetailContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/InvoiceDetailContainer.tsx
@@ -22,7 +22,7 @@ export const InvoiceDetailContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const invoiceResponse = await fetch(`/Invoice/Get/${projectId}?invoiceId=${invoiceId}`);
+      const invoiceResponse = await fetch(`/api/Invoice/Get/${projectId}?invoiceId=${invoiceId}`);
 
       if (invoiceResponse.ok) {
         const projectWithInvoice: ProjectWithInvoice =

--- a/Harvest.Web/ClientApp/src/Invoices/InvoiceListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/InvoiceListContainer.tsx
@@ -19,7 +19,7 @@ export const InvoiceListContainer = () => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await fetch(`/Invoice/List/?projectId=${projectId}`);
+      const response = await fetch(`/api/Invoice/List/?projectId=${projectId}`);
 
       if (response.ok) {
         getIsMounted() && setInvoices(await response.json());
@@ -32,7 +32,7 @@ export const InvoiceListContainer = () => {
   }, [projectId, getIsMounted]);
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/Project/Get/${projectId}`);
+      const response = await fetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();

--- a/Harvest.Web/ClientApp/src/Invoices/RecentInvoicesContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/RecentInvoicesContainer.tsx
@@ -19,7 +19,7 @@ export const RecentInvoicesContainer = (props: Props) => {
     const cb = async () => {
       // TODO: only fetch first 5 instead of chopping off client-side
       const response = await fetch(
-        `/Invoice/List/?projectId=${props.projectId}`
+        `/api/Invoice/List/?projectId=${props.projectId}`
       );
 
       if (response.ok) {

--- a/Harvest.Web/ClientApp/src/Projects/ProjectDetailContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectDetailContainer.tsx
@@ -32,7 +32,7 @@ export const ProjectDetailContainer = () => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await fetch(`/Project/Get/${projectId}`);
+      const response = await fetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const project = (await response.json()) as Project;
@@ -50,7 +50,7 @@ export const ProjectDetailContainer = () => {
   }
 
   const updateFiles = async (attachments: BlobFile[]) => {
-    const request = fetch(`/Request/Files/${projectId}`, {
+    const request = fetch(`/api/Request/Files/${projectId}`, {
       method: "POST",
       headers: {
         Accept: "application/json",
@@ -75,7 +75,7 @@ export const ProjectDetailContainer = () => {
 
   //cancel the project
   const cancelProject = async () => {
-    const request = fetch(`/Request/Cancel/${projectId}`, {
+    const request = fetch(`/api/Request/Cancel/${projectId}`, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/Harvest.Web/ClientApp/src/Projects/ProjectFields.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectFields.tsx
@@ -22,7 +22,7 @@ export const ProjectFields = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const getFields = async () => {
-      const response = await fetch("/Project/GetFields");
+      const response = await fetch("/api/Project/GetFields");
 
       if (response.ok) {
         const result = await response.json();

--- a/Harvest.Web/ClientApp/src/Projects/ProjectUnbilledButton.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectUnbilledButton.tsx
@@ -15,7 +15,7 @@ export const ProjectUnbilledButton = (props: Props) => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
       const response = await fetch(
-        `/expense/getunbilledtotal/${props.projectId}`
+        `/api/expense/getunbilledtotal/${props.projectId}`
       );
 
       if (response.ok) {

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -51,8 +51,8 @@ export const QuoteContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const quoteResponse = await fetch(`/Quote/Get/${projectId}`);
-      const pricingResponse = await fetch("/Rate/Active");
+      const quoteResponse = await fetch(`/api/Quote/Get/${projectId}`);
+      const pricingResponse = await fetch("/api/Rate/Active");
 
       if (quoteResponse.ok && pricingResponse.ok) {
         const projectWithQuote: ProjectWithQuote = await quoteResponse.json();
@@ -177,7 +177,7 @@ export const QuoteContainer = () => {
       }
     }
 
-    const request = fetch(`/Quote/Save/${projectId}?submit=${submit}`, {
+    const request = fetch(`/api/Quote/Save/${projectId}?submit=${submit}`, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteDisplayContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteDisplayContainer.tsx
@@ -23,7 +23,7 @@ export const QuoteDisplayContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const quoteResponse = await fetch(`/Quote/GetApproved/${projectId}`);
+      const quoteResponse = await fetch(`/api/Quote/GetApproved/${projectId}`);
 
       if (quoteResponse.ok) {
         const projectWithQuote: ProjectWithQuote = await quoteResponse.json();

--- a/Harvest.Web/ClientApp/src/Quotes/RejectQuote.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/RejectQuote.tsx
@@ -49,7 +49,7 @@ export const RejectQuote = (props: Props) => {
       return;
     }
 
-    const request = fetch(`/Request/RejectQuote/${props.project.id}`, {
+    const request = fetch(`/api/Request/RejectQuote/${props.project.id}`, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/Harvest.Web/ClientApp/src/Requests/AccountChangeContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/AccountChangeContainer.tsx
@@ -23,7 +23,7 @@ export const AccountChangeContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/Project/Get/${projectId}`);
+      const response = await fetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
@@ -41,7 +41,7 @@ export const AccountChangeContainer = () => {
 
   //TODO: require PI or supervisor access after updating auth policies
   const changeAccounts = async () => {
-    const request = fetch(`/Request/ChangeAccount/${projectId}`, {
+    const request = fetch(`/api/Request/ChangeAccount/${projectId}`, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/Harvest.Web/ClientApp/src/Requests/AccountsInput.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/AccountsInput.tsx
@@ -56,7 +56,7 @@ export const AccountsInput = (props: Props) => {
   const onSearch = async (query: string) => {
     setIsSearchLoading(true);
 
-    const response = await fetch(`/financialaccount/get?account=${query}`);
+    const response = await fetch(`/api/financialaccount/get?account=${query}`);
 
     if (response.ok) {
       if (response.status === 204) {

--- a/Harvest.Web/ClientApp/src/Requests/ApprovalContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/ApprovalContainer.tsx
@@ -30,7 +30,7 @@ export const ApprovalContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const quoteResponse = await fetch(`/Quote/Get/${projectId}`);
+      const quoteResponse = await fetch(`/api/Quote/Get/${projectId}`);
 
       if (quoteResponse.ok) {
         const projectWithQuote: ProjectWithQuote = await quoteResponse.json();
@@ -50,7 +50,7 @@ export const ApprovalContainer = () => {
   const approve = async () => {
     const model = { accounts };
 
-    const request = fetch(`/Request/Approve/${projectId}`, {
+    const request = fetch(`/api/Request/Approve/${projectId}`, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/Harvest.Web/ClientApp/src/Requests/Crops.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/Crops.tsx
@@ -41,7 +41,7 @@ export const Crops = (props: Props) => {
     const onSearch = async () => {
       setIsSearchLoading(true);
 
-      const response = await fetch(`/Crop/Search?type=${props.cropType}`);
+      const response = await fetch(`/api/Crop/Search?type=${props.cropType}`);
 
       if (response.ok) {
         if (response.status === 204) {

--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
@@ -51,7 +51,7 @@ export const RequestContainer = () => {
   useEffect(() => {
     // load original request if this is a change request
     const cb = async () => {
-      const response = await fetch(`/Project/Get/${projectId}`);
+      const response = await fetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
@@ -82,7 +82,7 @@ export const RequestContainer = () => {
       return;
     }
 
-    const request = fetch(`/Request/Create`, {
+    const request = fetch(`/api/Request/Create`, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/Harvest.Web/ClientApp/src/Requests/SearchPerson.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/SearchPerson.tsx
@@ -23,7 +23,7 @@ export const SearchPerson = (props: Props) => {
   const onSearch = async (query: string) => {
     setIsSearchLoading(true);
 
-    const response = await fetch(`/people/search?query=${query}`);
+    const response = await fetch(`/api/people/search?query=${query}`);
 
     if (response.ok) {
       if (response.status === 204) {

--- a/Harvest.Web/ClientApp/src/Shared/FileUpload.tsx
+++ b/Harvest.Web/ClientApp/src/Shared/FileUpload.tsx
@@ -44,7 +44,7 @@ export const FileUpload = (props: Props) => {
   useEffect(() => {
     // grab the sas token right away
     const cb = async () => {
-      const response = await fetch(`/File/GetUploadDetails`);
+      const response = await fetch(`/api/File/GetUploadDetails`);
 
       if (response.ok) {
         const url = await response.text();

--- a/Harvest.Web/ClientApp/src/Tickets/RecentTicketsContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/RecentTicketsContainer.tsx
@@ -18,7 +18,7 @@ export const RecentTicketsContainer = (props: Props) => {
   useEffect(() => {
     const cb = async () => {
       const response = await fetch(
-        `/Ticket/GetList?projectId=${props.projectId}&maxRows=${maxRows}`
+        `/api/Ticket/GetList?projectId=${props.projectId}&maxRows=${maxRows}`
       );
 
       if (response.ok) {

--- a/Harvest.Web/ClientApp/src/Tickets/TicketAttachments.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketAttachments.tsx
@@ -29,7 +29,7 @@ export const TicketAttachments = (props: Props) => {
   const getIsMounted = useIsMounted();
   const updateFiles = async (attachments: BlobFile[]) => {
     const request = fetch(
-      `/Ticket/UploadFiles/${projectId}/${props.ticket.id}/`,
+      `/api/Ticket/UploadFiles/${projectId}/${props.ticket.id}/`,
       {
         method: "POST",
         headers: {

--- a/Harvest.Web/ClientApp/src/Tickets/TicketCreate.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketCreate.tsx
@@ -42,7 +42,7 @@ export const TicketCreate = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/Project/Get/${projectId}`);
+      const response = await fetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
@@ -67,7 +67,7 @@ export const TicketCreate = () => {
       return;
     }
 
-    const request = fetch(`/Ticket/Create?projectId=${projectId}`, {
+    const request = fetch(`/api/Ticket/Create?projectId=${projectId}`, {
       method: "POST",
       headers: {
         Accept: "application/json",

--- a/Harvest.Web/ClientApp/src/Tickets/TicketDetailContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketDetailContainer.tsx
@@ -27,7 +27,7 @@ export const TicketDetailContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/Project/Get/${projectId}`);
+      const response = await fetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
@@ -40,7 +40,7 @@ export const TicketDetailContainer = () => {
 
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/Ticket/Get/${projectId}/${ticketId}`);
+      const response = await fetch(`/api/Ticket/Get/${projectId}/${ticketId}`);
 
       if (response.ok) {
         const tick: TicketDetails = await response.json();
@@ -57,7 +57,7 @@ export const TicketDetailContainer = () => {
 
   const closeTicket = async () => {
     const request = fetch(
-      `/Ticket/Close?projectId=${projectId}&ticketId=${ticketId}`,
+      `/api/Ticket/Close?projectId=${projectId}&ticketId=${ticketId}`,
       {
         method: "POST",
         headers: {

--- a/Harvest.Web/ClientApp/src/Tickets/TicketReply.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketReply.tsx
@@ -23,7 +23,7 @@ export const TicketReply = (props: Props) => {
     // TODO: validation
 
     const request = fetch(
-      `/Ticket/Reply?projectId=${projectId}&ticketId=${ticket.id}`,
+      `/api/Ticket/Reply?projectId=${projectId}&ticketId=${ticket.id}`,
       {
         method: "POST",
         headers: {

--- a/Harvest.Web/ClientApp/src/Tickets/TicketWorkNotesEdit.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketWorkNotesEdit.tsx
@@ -17,7 +17,7 @@ export const TicketWorkNotesEdit = (props: Props) => {
     // TODO: validation
 
     const request = fetch(
-      `/Ticket/UpdateWorkNotes?projectId=${props.projectId}&ticketId=${ticket.id}`,
+      `/api/Ticket/UpdateWorkNotes?projectId=${props.projectId}&ticketId=${ticket.id}`,
       {
         method: "POST",
         headers: {

--- a/Harvest.Web/ClientApp/src/Tickets/TicketsContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketsContainer.tsx
@@ -17,7 +17,7 @@ export const TicketsContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/Project/Get/${projectId}`);
+      const response = await fetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
@@ -30,7 +30,7 @@ export const TicketsContainer = () => {
 
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/Ticket/GetList?projectId=${projectId}`);
+      const response = await fetch(`/api/Ticket/GetList?projectId=${projectId}`);
 
       if (response.ok) {
         getIsMounted() && setTickets(await response.json());

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -28,16 +28,6 @@ namespace Harvest.Web.Controllers.Api
             _expenseService = expenseService;
         }
 
-        public ActionResult Entry()
-        {
-            return View("React");
-        }
-
-        public ActionResult Unbilled(int id)
-        {
-            return View("React");
-        }
-
         [HttpPost]
         [Authorize(Policy = AccessCodes.WorkerAccess)]
         [Consumes(MediaTypeNames.Application.Json)]

--- a/Harvest.Web/Controllers/Api/InvoiceController.cs
+++ b/Harvest.Web/Controllers/Api/InvoiceController.cs
@@ -59,13 +59,6 @@ namespace Harvest.Web.Controllers.Api
                 .ToArrayAsync());
         }
 
-        // Get react view, whose router should choose InvoiceDetailContainer
-        [HttpGet("invoice/details/{projectId}/{invoiceId}")]
-        public ActionResult Details(int projectId, int invoiceId)
-        {
-            return View("React");
-        }
-
         [HttpPost]
         [Authorize(Policy = AccessCodes.FieldManagerAccess)]
         public async Task<ActionResult> DoCloseout(int projectId)

--- a/Harvest.Web/Controllers/Api/PeopleController.cs
+++ b/Harvest.Web/Controllers/Api/PeopleController.cs
@@ -21,7 +21,7 @@ namespace Harvest.Web.Controllers.Api
         }
 
         // Search people based on kerb or email
-        [HttpGet("/people/search")]
+        [HttpGet("/api/people/search")]
         public async Task<ActionResult> Search(string query)
         {
             User user;

--- a/Harvest.Web/Controllers/Api/ProjectController.cs
+++ b/Harvest.Web/Controllers/Api/ProjectController.cs
@@ -36,31 +36,6 @@ namespace Harvest.Web.Controllers.Api
             _invoiceService = invoiceService;
         }
 
-        public ActionResult Index()
-        {
-            return View("React");
-        }
-
-        public ActionResult Mine()
-        {
-            return View("React");
-        }
-
-        public ActionResult Map()
-        {
-            return View("React");
-        }
-
-        public ActionResult NeedsAttention()
-        {
-            return View("React");
-        }
-
-        public ActionResult Invoices()
-        {
-            return View("React");
-        }
-
         [Authorize(Policy = AccessCodes.WorkerAccess)]
         public async Task<ActionResult> All()
         {
@@ -133,21 +108,6 @@ namespace Harvest.Web.Controllers.Api
                 .Include(p => p.PrincipalInvestigator)
                 .Where(p => p.IsActive && p.PrincipalInvestigatorId == user.Id)
                 .ToArrayAsync());
-        }
-
-
-
-        public ActionResult Details(int projectId)
-        {
-            // TODO: move routes so react handles this natively and place API stuff in own controller
-            return View("React");
-        }
-
-        [Authorize(Policy = AccessCodes.SupervisorAccess)]
-        public ActionResult Closeout(int projectId)
-        {
-            // TODO: move routes so react handles this natively and place API stuff in own controller
-            return View("React");
         }
 
         // Returns JSON info of the project

--- a/Harvest.Web/Controllers/Api/ProjectController.cs
+++ b/Harvest.Web/Controllers/Api/ProjectController.cs
@@ -13,7 +13,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Serilog;
 
-namespace Harvest.Web.Controllers
+namespace Harvest.Web.Controllers.Api
 {
     [Authorize]
     public class ProjectController : SuperController

--- a/Harvest.Web/Controllers/Api/QuoteController.cs
+++ b/Harvest.Web/Controllers/Api/QuoteController.cs
@@ -59,20 +59,6 @@ namespace Harvest.Web.Controllers.Api
             return Ok(model);
         }
 
-        // Create a quote for project ID
-        [Authorize(Policy = AccessCodes.SupervisorAccess)]
-        [HttpGet]
-        public ActionResult Create(int projectId)
-        {
-            return View("React");
-        }
-
-        [HttpGet]
-        public ActionResult Details(int projectId)
-        {
-            return View("React");
-        }
-
         [Authorize(Policy = AccessCodes.SupervisorAccess)]
         [HttpPost]
         public async Task<ActionResult> Save(int projectId, bool submit, [FromBody] QuoteDetail quoteDetail)

--- a/Harvest.Web/Controllers/Api/RequestController.cs
+++ b/Harvest.Web/Controllers/Api/RequestController.cs
@@ -44,28 +44,6 @@ namespace Harvest.Web.Controllers.Api
             _historyService = historyService;
         }
 
-        // create a new request via react
-        [HttpGet]
-        public ActionResult Create()
-        {
-            return View("React");
-        }
-
-        // Approve a quote for the project
-        [HttpGet]
-        [Authorize(Policy = AccessCodes.PrincipalInvestigator)]
-        public ActionResult Approve(int projectId)
-        {
-            return View("React");
-        }
-
-        [HttpGet]
-        [Authorize(Policy = AccessCodes.PrincipalInvestigator)]
-        public ActionResult ChangeAccount(int projectId)
-        {
-            return View("React");
-        }
-
         [HttpPost]
         [Authorize(Policy = AccessCodes.FieldManagerAccess)]
         public async Task<ActionResult> Cancel(int projectId)

--- a/Harvest.Web/Controllers/Api/TicketController.cs
+++ b/Harvest.Web/Controllers/Api/TicketController.cs
@@ -51,34 +51,6 @@ namespace Harvest.Web.Controllers.Api
         }
 
         [HttpGet]
-        [Authorize(Policy = AccessCodes.PrincipalInvestigator)]
-        public ActionResult List(int id)
-        {
-            return View("React");
-        }
-
-        // create a new ticket via react
-        [HttpGet]
-        [Authorize(Policy = AccessCodes.PrincipalInvestigator)]
-        public ActionResult Create()
-        {
-            return View("React");
-        }
-
-        [HttpGet]
-        [Authorize(Policy = AccessCodes.SupervisorAccess)]
-        public ActionResult NeedsAttention()
-        {
-            return View("React");
-        }
-
-        [HttpGet]
-        public ActionResult Mine()
-        {
-            return View("React");
-        }
-
-        [HttpGet]
         public async Task<ActionResult> RequiringPIAttention(int? limit)
         {
             var user = await _userService.GetCurrentUser();
@@ -169,14 +141,8 @@ namespace Harvest.Web.Controllers.Api
 
             return Ok(project);
         }
-        [HttpGet("[controller]/[action]/{projectId}/{ticketId}")]
-        [Authorize(Policy = AccessCodes.PrincipalInvestigator)]
-        public ActionResult Details(int projectId, int ticketId)
-        {
-            return View("React");
-        }
 
-        [HttpGet("[controller]/[action]/{projectId}/{ticketId}")]
+        [HttpGet("/api/[controller]/[action]/{projectId}/{ticketId}")]
         [Authorize(Policy = AccessCodes.PrincipalInvestigator)]
         public async Task<ActionResult> Get(int projectId, int ticketId)
         {
@@ -245,7 +211,7 @@ namespace Harvest.Web.Controllers.Api
         }
 
         [Authorize(Policy = AccessCodes.PrincipalInvestigator)]
-        [HttpPost("[controller]/[action]/{projectId}/{ticketId}")]
+        [HttpPost("/api/[controller]/[action]/{projectId}/{ticketId}")]
         public async Task<ActionResult> UploadFiles(int projectId, int ticketId, [FromBody] TicketFilesModel model)
         {
             var currentUser = await _userService.GetCurrentUser();

--- a/Harvest.Web/Controllers/HomeController.cs
+++ b/Harvest.Web/Controllers/HomeController.cs
@@ -8,6 +8,7 @@ namespace Harvest.Web.Controllers
     {
         public ActionResult Index()
         {
+            System.Console.WriteLine(HttpContext.Request.Protocol);
             return View("React");
         }
     }

--- a/Harvest.Web/Controllers/HomeController.cs
+++ b/Harvest.Web/Controllers/HomeController.cs
@@ -8,7 +8,6 @@ namespace Harvest.Web.Controllers
     {
         public ActionResult Index()
         {
-            System.Console.WriteLine(HttpContext.Request.Protocol);
             return View("React");
         }
     }

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -219,10 +219,13 @@ namespace Harvest.Web
                     name: "API",
                     pattern: "/api/{controller=Project}/{action=Index}/{projectId?}");
 
-                // Everything else routes to react (served from home controller)
-                endpoints.MapFallbackToController("Index", "Home");
-
-                // 404 errors will be handled by react/SPA
+                // any other nonfile route should be handled by the spa, except leave the sockjs route alone (could be dev only)
+                endpoints.MapControllerRoute(
+                    name: "react",
+                    pattern: "{*path:nonfile}",
+                    defaults: new { controller = "Home", action = "Index" },
+                    constraints: new { path = new RegexRouteConstraint("^(?!sockjs-node).*$") }
+                );
             });
 
             // SPA needs to kick in for all paths during development

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -206,6 +206,7 @@ namespace Harvest.Web
 
             app.UseEndpoints(endpoints =>
             {
+                // default for MVC server-side endpoints
                 endpoints.MapControllerRoute(
                     name: "default",
                     pattern: "{controller}/{action}/{id?}",
@@ -213,20 +214,18 @@ namespace Harvest.Web
                     constraints: new { controller = "(rate|permissions|crop)" }
                 );
 
+                // API routes map to all other controllers
                 endpoints.MapControllerRoute(
-                    name: "Projects",
-                    pattern: "{controller=Home}/{action=Index}/{projectId?}");
+                    name: "API",
+                    pattern: "/api/{controller=Project}/{action=Index}/{projectId?}");
 
-                // Handle 404 errors, but only in production.  In dev we want to let some requests fallthrough for webpack.
-                if (!env.IsDevelopment())
-                {
-                    //similar to MapFallbackToController("Index", "Error"), but adds a statusCode value of 404
-                    endpoints.MapDynamicControllerRoute<RewriteError404>("{*path:nonfile}");
-                }
+                // Everything else routes to react (served from home controller)
+                endpoints.MapFallbackToController("Index", "Home");
+
+                // 404 errors will be handled by react/SPA
             });
 
             // SPA needs to kick in for all paths during development
-            // TODO: create SPA 404 page or have SPA redirect back to MVC app on invalid route
             app.UseSpa(spa =>
             {
                 spa.Options.SourcePath = "ClientApp";

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -211,7 +211,7 @@ namespace Harvest.Web
                     name: "default",
                     pattern: "{controller}/{action}/{id?}",
                     defaults: new { controller = "Home", action = "Index" },
-                    constraints: new { controller = "(rate|permissions|crop)" }
+                    constraints: new { controller = "(rate|permissions|crop|home)" }
                 );
 
                 // API routes map to all other controllers

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -220,13 +220,21 @@ namespace Harvest.Web
                     name: "API",
                     pattern: "/api/{controller=Project}/{action=Index}/{projectId?}");
 
-                // any other nonfile route should be handled by the spa, except leave the sockjs route alone (could be dev only)
-                endpoints.MapControllerRoute(
-                    name: "react",
-                    pattern: "{*path:nonfile}",
-                    defaults: new { controller = "Home", action = "Index" },
-                    constraints: new { path = new RegexRouteConstraint("^(?!sockjs-node).*$") }
-                );
+                // any other nonfile route should be handled by the spa, except leave the sockjs route alone if we are in dev mode (hot reloading)
+                if (env.IsDevelopment()) {
+                    endpoints.MapControllerRoute(
+                        name: "react",
+                        pattern: "{*path:nonfile}",
+                        defaults: new { controller = "Home", action = "Index" },
+                        constraints: new { path = new RegexRouteConstraint("^(?!sockjs-node).*$") }
+                    );
+                } else {
+                    endpoints.MapControllerRoute(
+                        name: "react",
+                        pattern: "{*path:nonfile}",
+                        defaults: new { controller = "Home", action = "Index" }
+                    );
+                }
             });
 
             // SPA needs to kick in for all paths during development

--- a/Harvest.Web/Views/Shared/_Layout.cshtml
+++ b/Harvest.Web/Views/Shared/_Layout.cshtml
@@ -88,7 +88,7 @@
                     @if (await UserService.HasAccess(AccessCodes.WorkerAccess))
                     {
                         <li class="nav-item">
-                            <a asp-controller="Expense" asp-action="Entry" class="nav-link">Expenses</a>
+                            <a href="/expense/entry" class="nav-link">Expenses</a>
                         </li>
                     }
                     <li class="nav-item">

--- a/Test/TestsControllers/ProjectControllerTests.cs
+++ b/Test/TestsControllers/ProjectControllerTests.cs
@@ -1,5 +1,5 @@
 ﻿using Harvest.Core.Models;
-using Harvest.Web.Controllers;
+using Harvest.Web.Controllers.Api;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Shouldly;


### PR DESCRIPTION
We only had one controller that wasn't in the API folder, so I moved that one and now all except a few MVC controllers are using the new "API" route.  Any route in our app that doesn't start with /api now automatically returns the react page, so we no longer need to add placeholder react actions.  This does mean that react is now handling our 404s, which I think is fine.  If we want to handle API 404s differently we still can, but page 404s are react-router.

I think I've updated all the API calls, custom routes via attributes, and other edge cases, but I'll need to test more to be sure.

One thing to note is the webpack sockets connection was failing in dev for the same reason it used to fail when we added a 404 -- the fallback was catching it.  So I do a semi-hacky thing and our react fallback only fires on pages that don't start with `sockjs-node`.  I don't know if there's a better way, and it's not that bad.

closes #271