### PR TITLE
Possibly better way of getting dynamic scripts from CRA

### DIFF
--- a/Harvest.Web/Views/Shared/Components/DynamicScripts/Default.cshtml
+++ b/Harvest.Web/Views/Shared/Components/DynamicScripts/Default.cshtml
@@ -1,8 +1,6 @@
 @model Harvest.Web.Views.Shared.Components.DynamicScripts.DynamicScriptModel
 
-<script>@Html.Raw(Model.Runtime)</script>
-
 @foreach (var script in Model.Scripts)
 {
-    <script src="/static/js/@script"></script>
+    @Html.Raw(script)
 }

--- a/Harvest.Web/Views/Shared/Components/DynamicScripts/DynamicScripts.cs
+++ b/Harvest.Web/Views/Shared/Components/DynamicScripts/DynamicScripts.cs
@@ -1,7 +1,5 @@
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -20,56 +18,19 @@ namespace Harvest.Web.Views.Shared.Components.DynamicScripts
         }
         public async Task<IViewComponentResult> InvokeAsync()
         {
-            var files = _fileProvider.GetDirectoryContents("ClientApp/build/static/js");
+            // Get the CRA generated index file, which includes optimized scripts
+            var indexPage = _fileProvider.GetFileInfo("ClientApp/build/index.html");
 
-            /* 
-             * Get the important JS files in the static build folder
-             * Should include the following files:
-             * - [num].[hash].chunk.js (determined from the generated index.html by CRA)
-             * - main.*.js
-             * - runtime-main.*.js
+            // read the file
+            var fileContents = await File.ReadAllTextAsync(indexPage.PhysicalPath);
 
-             * Other chunks do not need to be included here, since they will be dynamically requested only when needed
+            // find all script tags
+            var scriptTags = Regex.Matches(fileContents, "<script.*?</script>", RegexOptions.Singleline);
 
-             =======
-             We would like to inline the runtime-main file, then load 3.*.chunk.js, and then main.*.chunk.js
-            */
+            // get the script tags as strings
+            var scriptTagsAsStrings = scriptTags.Select(m => m.Value).ToArray();
 
-            var model = new DynamicScriptModel();
-            var runtimeFile = files.Where(f => Regex.IsMatch(f.Name, "^.*runtime-main.*\\.js$")).First();
-
-            // read the entire runtime-main file
-            using (var reader = runtimeFile.CreateReadStream())
-            {
-                using (var streamReader = new StreamReader(reader))
-                {
-                    // we only care about the first line, which is just a bunch of minified JS
-                    model.Runtime = await streamReader.ReadLineAsync();
-                }
-            }
-
-            var scripts = new List<string>();
-
-            // Assumption: We need the chunk file that contains code from react.production.min.js
-            // Assumption: The chunk file will always be accompanied by a corresponding [chunk file name].LICENSE.txt file that contains the string "react.production"
-            // Assumption: No other LICENSE.txt file will contain "react.production" (though it shouldn't break anything if it does happen)
-            var regex = new Regex("react\\.production");
-            foreach (var file in files.Where(f => Regex.IsMatch(f.Name, "^[0-9]*\\..*\\.chunk\\.js\\.LICENSE.txt$")))
-            {
-                foreach (var line in File.ReadLines(file.PhysicalPath))
-                {
-                    if (regex.IsMatch(line))
-                    {
-                        scripts.Add(file.Name.Replace(".LICENSE.txt", ""));
-                        break;
-                    }
-                }
-            }
-
-            // now add in main.*.chunk.js
-            scripts.AddRange(files.Where(f => Regex.IsMatch(f.Name, "^.*main\\..*\\.chunk\\.js$")).Select(f => f.Name));
-
-            model.Scripts = scripts.ToArray();
+            var model = new DynamicScriptModel { Scripts = scriptTagsAsStrings };
 
             return View(model);
         }
@@ -78,6 +39,5 @@ namespace Harvest.Web.Views.Shared.Components.DynamicScripts
     public class DynamicScriptModel
     {
         public string[] Scripts { get; set; }
-        public string Runtime { get; set; }
     }
 }

--- a/Harvest.Web/Views/Shared/Components/DynamicStyles/Default.cshtml
+++ b/Harvest.Web/Views/Shared/Components/DynamicStyles/Default.cshtml
@@ -2,5 +2,5 @@
 
 @foreach (var style in Model)
 {
-    <link href="/static/css/@style" rel="stylesheet">
+    @Html.Raw(style)
 }

--- a/Harvest.Web/Views/Shared/Components/DynamicStyles/DynamicStyles.cs
+++ b/Harvest.Web/Views/Shared/Components/DynamicStyles/DynamicStyles.cs
@@ -25,11 +25,14 @@ namespace Harvest.Web.Views.Shared.Components.DynamicStyles
             var fileContents = await File.ReadAllTextAsync(indexPage.PhysicalPath);
 
             // find all link tags with the rel attribute set to stylesheet
-            var styleSheetLinks = Regex.Matches(fileContents, "<link.*rel=\"stylesheet\".*>", RegexOptions.IgnoreCase);
+            var linkTags = Regex.Matches(fileContents, "<link.*?>", RegexOptions.IgnoreCase);
 
-            var styleLinksAsString = styleSheetLinks.Cast<Match>().Select(m => m.Value).ToList();
+            // make an array with just the stylesheet links
+            var styleLinksAsStrings = linkTags.Where(m => m.Value.Contains("rel=\"stylesheet\""))
+                .Select(m => m.Value)
+                .ToArray();
 
-            return View(styleSheetLinks.Select(m => m.Value).ToArray());
+            return View(styleLinksAsStrings);
         }
     }
 }


### PR DESCRIPTION
Previous approach involved reading the contents of the scripts/styles directories.  New way just reads the compiled index.html file and spits out the relevant sections.  I think it's probably a better approach because we'll be guaranteed to get the ordering right, and any future changes to build chunks should automatically update.

I do feel a little dirty about reading the contents of a file as a string and then doing regex over HTML, but it's a known file and it's pretty small, plus we cache the output so I don't see the harm.