### PR TITLE
Add antiforgery token to all API requests

### DIFF
--- a/Harvest.Web/ClientApp/src/Closeout/CloseoutConfirmationContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Closeout/CloseoutConfirmationContainer.tsx
@@ -12,6 +12,7 @@ import { useConfirmationDialog } from "../Shared/ConfirmationDialog";
 import { ShowFor } from "../Shared/ShowFor";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import AppContext from "../Shared/AppContext";
+import { authenticatedFetch } from "../Util/Api";
 
 interface RouteParams {
   projectId?: string;
@@ -28,7 +29,7 @@ export const CloseoutConfirmationContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
       if (response.ok) {
         const proj: Project = await response.json();
         getIsMounted() && setProject(proj);
@@ -66,7 +67,7 @@ export const CloseoutConfirmationContainer = () => {
       return;
     }
 
-    const request = fetch(`/api/Invoice/DoCloseout/${projectId}`, {
+    const request = authenticatedFetch(`/api/Invoice/DoCloseout/${projectId}`, {
       method: "POST",
     });
 

--- a/Harvest.Web/ClientApp/src/Closeout/CloseoutContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Closeout/CloseoutContainer.tsx
@@ -12,6 +12,7 @@ import { roundToTwo } from "../Util/Calculations";
 import { useConfirmationDialog } from "../Shared/ConfirmationDialog";
 import { ShowFor } from "../Shared/ShowFor";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 import { formatCurrency } from "../Util/NumberFormatting";
 
 interface RouteParams {
@@ -35,7 +36,7 @@ export const CloseoutContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
       if (response.ok) {
         const proj: Project = await response.json();
         getIsMounted() && setProject(proj);
@@ -89,7 +90,7 @@ export const CloseoutContainer = () => {
       return;
     }
 
-    const request = fetch(`/api/Invoice/InitiateCloseout/${projectId}`, {
+    const request = authenticatedFetch(`/api/Invoice/InitiateCloseout/${projectId}`, {
       method: "POST",
     });
 

--- a/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
@@ -28,6 +28,7 @@ import * as yup from "yup";
 import { useQuery } from "../Shared/UseQuery";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { validatorOptions } from "../constants";
+import { authenticatedFetch } from "../Util/Api";
 import { convertCamelCase } from "../Util/StringFormatting";
 
 interface RouteParams {
@@ -84,7 +85,7 @@ export const ExpenseEntryContainer = () => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await fetch("/api/Rate/Active");
+      const response = await authenticatedFetch("/api/Rate/Active");
 
       if (response.ok) {
         const rates: Rate[] = await response.json();
@@ -101,7 +102,7 @@ export const ExpenseEntryContainer = () => {
   useEffect(() => {
     // get project in order to determine if it can accept new expenses
     const cb = async () => {
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const project = (await response.json()) as Project;
@@ -180,12 +181,8 @@ export const ExpenseEntryContainer = () => {
         )
     );
 
-    const request = fetch(`/api/Expense/Create/${projectId}`, {
+    const request = authenticatedFetch(`/api/Expense/Create/${projectId}`, {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify(expensesBody),
     });
 

--- a/Harvest.Web/ClientApp/src/Expenses/ProjectSelection.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ProjectSelection.tsx
@@ -4,6 +4,7 @@ import { FormGroup, Input } from "reactstrap";
 
 import { Project } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 interface Props {
   selectedProject: (projectId: number) => void;
@@ -16,7 +17,7 @@ export const ProjectSelection = (props: Props) => {
   useEffect(() => {
     // get list of projects
     const cb = async () => {
-      const response = await fetch(`/api/Project/Active`);
+      const response = await authenticatedFetch(`/api/Project/Active`);
 
       if (response.ok) {
         const projects = await response.json();

--- a/Harvest.Web/ClientApp/src/Expenses/UnbilledExpensesContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/UnbilledExpensesContainer.tsx
@@ -6,6 +6,7 @@ import { ExpenseTable } from "./ExpenseTable";
 import { ShowFor } from "../Shared/ShowFor";
 import { formatCurrency } from "../Util/NumberFormatting";
 import { useConfirmationDialog } from "../Shared/ConfirmationDialog";
+import { authenticatedFetch } from "../Util/Api";
 import { usePromiseNotification } from "../Util/Notifications";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { ProjectHeader } from "../Shared/ProjectHeader";
@@ -42,7 +43,7 @@ export const UnbilledExpensesContainer = (props: Props) => {
     if (projectId === undefined) return;
 
     const cb = async () => {
-      const response = await fetch(`/api/Expense/GetUnbilled/${projectId}`);
+      const response = await authenticatedFetch(`/api/Expense/GetUnbilled/${projectId}`);
 
       if (response.ok) {
         const expenses: Expense[] = await response.json();
@@ -62,7 +63,7 @@ export const UnbilledExpensesContainer = (props: Props) => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const project = (await response.json()) as Project;
@@ -85,12 +86,8 @@ export const UnbilledExpensesContainer = (props: Props) => {
       return;
     }
 
-    const request = fetch(`/api/Expense/Delete?expenseId=${expense.id}`, {
+    const request = authenticatedFetch(`/api/Expense/Delete?expenseId=${expense.id}`, {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
     });
     setNotification(request, "Removing Expense", () => {
       if (getIsMounted()) {

--- a/Harvest.Web/ClientApp/src/Fields/FieldLayers.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldLayers.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { LayersControl, GeoJSON, Popup, LayerGroup } from "react-leaflet";
 import { Field, Project } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 interface Props {
   project: Project;
@@ -18,7 +19,7 @@ export const FieldLayers = (props: Props) => {
       const endDate = new Date(props.project.end);
       const projectId = props.project.id;
 
-      const activeFieldResponse = await fetch(
+      const activeFieldResponse = await authenticatedFetch(
         `/api/Field/Active?start=${startDate.toLocaleDateString()}&end=${endDate.toLocaleDateString()}&projectId=${projectId}`
       );
 

--- a/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
+import { authenticatedFetch } from "../Util/Api";
 import { StatusToActionRequired } from "../Util/MessageHelpers";
 import { Project, Ticket } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
@@ -13,7 +14,7 @@ export const FieldManagerHome = () => {
   useEffect(() => {
     // get info on projects requiring approval
     const getProjects = async () => {
-      const response = await fetch("/api/project/RequiringManagerAttention");
+      const response = await authenticatedFetch("/api/project/RequiringManagerAttention");
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);
@@ -25,7 +26,7 @@ export const FieldManagerHome = () => {
 
   useEffect(() => {
     const getTicketsWaitingForMe = async () => {
-      const response = await fetch(
+      const response = await authenticatedFetch(
         "/api/ticket/RequiringManagerAttention?limit=3"
       );
       if (getIsMounted()) {

--- a/Harvest.Web/ClientApp/src/Home/PIHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/PIHome.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { Project, Ticket } from "../types";
+import { authenticatedFetch } from "../Util/Api";
 import { StatusToActionRequired } from "../Util/MessageHelpers";
 import { useIsMounted } from "../Shared/UseIsMounted";
 
@@ -12,7 +13,7 @@ export const PIHome = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const getProjectsWaitingForMe = async () => {
-      const response = await fetch("/api/project/RequiringPIAttention");
+      const response = await authenticatedFetch("/api/project/RequiringPIAttention");
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);
@@ -24,7 +25,7 @@ export const PIHome = () => {
 
   useEffect(() => {
     const getTicketsWaitingForMe = async () => {
-      const response = await fetch("/api/ticket/RequiringPIAttention?limit=3");
+      const response = await authenticatedFetch("/api/ticket/RequiringPIAttention?limit=3");
       if (getIsMounted()) {
         const tickets: Ticket[] = await response.json();
         getIsMounted() && setTickets(tickets);

--- a/Harvest.Web/ClientApp/src/Home/SupervisorHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/SupervisorHome.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Project, Ticket } from "../types";
+import { authenticatedFetch } from "../Util/Api";
 import { StatusToActionRequired } from "../Util/MessageHelpers";
 import { useIsMounted } from "../Shared/UseIsMounted";
 
@@ -12,7 +13,7 @@ export const SupervisorHome = () => {
   useEffect(() => {
     // get info on projects requiring approval
     const getProjects = async () => {
-      const response = await fetch("/api/project/RequiringManagerAttention");
+      const response = await authenticatedFetch("/api/project/RequiringManagerAttention");
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);
@@ -24,7 +25,7 @@ export const SupervisorHome = () => {
 
   useEffect(() => {
     const getTicketsWaitingForMe = async () => {
-      const response = await fetch(
+      const response = await authenticatedFetch(
         "/api/ticket/RequiringManagerAttention?limit=3"
       );
       if (getIsMounted()) {

--- a/Harvest.Web/ClientApp/src/Home/WorkerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/WorkerHome.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import { Project } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 export const WorkerHome = () => {
   const [projects, setProjects] = useState<Project[]>([]);
@@ -10,7 +11,7 @@ export const WorkerHome = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const getProjectsWithRecentExpenses = async () => {
-      const response = await fetch("/api/expense/GetRecentExpensedProjects");
+      const response = await authenticatedFetch("/api/expense/GetRecentExpensedProjects");
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);

--- a/Harvest.Web/ClientApp/src/Invoices/InvoiceDetailContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/InvoiceDetailContainer.tsx
@@ -5,6 +5,7 @@ import { ProjectWithInvoice } from "../types";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { InvoiceDisplay } from "./InvoiceDisplay";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 // Lazy load quote pdf link since it's a large JS file and causes a console warning
 const InvoicePDFLink = React.lazy(() => import("../Pdf/InvoicePDFLink"));
@@ -22,7 +23,7 @@ export const InvoiceDetailContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const invoiceResponse = await fetch(
+      const invoiceResponse = await authenticatedFetch(
         `/api/Invoice/Get/${projectId}?invoiceId=${invoiceId}`
       );
 

--- a/Harvest.Web/ClientApp/src/Invoices/InvoiceListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/InvoiceListContainer.tsx
@@ -5,6 +5,7 @@ import { Invoice, Project } from "../types";
 import { InvoiceTable } from "./InvoiceTable";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { ProjectHeader } from "../Shared/ProjectHeader";
+import { authenticatedFetch } from "../Util/Api";
 
 interface RouteParams {
   projectId?: string;
@@ -19,7 +20,7 @@ export const InvoiceListContainer = () => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await fetch(`/api/Invoice/List/?projectId=${projectId}`);
+      const response = await authenticatedFetch(`/api/Invoice/List/?projectId=${projectId}`);
 
       if (response.ok) {
         getIsMounted() && setInvoices(await response.json());
@@ -32,7 +33,7 @@ export const InvoiceListContainer = () => {
   }, [projectId, getIsMounted]);
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();

--- a/Harvest.Web/ClientApp/src/Invoices/RecentInvoicesContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/RecentInvoicesContainer.tsx
@@ -5,6 +5,7 @@ import { Invoice } from "../types";
 import { InvoiceTable } from "./InvoiceTable";
 import { ShowFor } from "../Shared/ShowFor";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 interface Props {
   projectId?: string;
@@ -18,7 +19,7 @@ export const RecentInvoicesContainer = (props: Props) => {
   useEffect(() => {
     const cb = async () => {
       // TODO: only fetch first 5 instead of chopping off client-side
-      const response = await fetch(
+      const response = await authenticatedFetch(
         `/api/Invoice/List/?projectId=${props.projectId}&maxRows=5`
       );
 

--- a/Harvest.Web/ClientApp/src/Projects/ProjectDetailContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectDetailContainer.tsx
@@ -23,6 +23,7 @@ import { usePromiseNotification } from "../Util/Notifications";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { useHistory } from "react-router-dom";
 import { ProjectAlerts } from "./ProjectAlerts";
+import { authenticatedFetch } from "../Util/Api";
 
 interface RouteParams {
   projectId?: string;
@@ -42,7 +43,7 @@ export const ProjectDetailContainer = () => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
       setIsLoading(true);
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const project = (await response.json()) as Project;
@@ -57,12 +58,8 @@ export const ProjectDetailContainer = () => {
   }, [projectId, getIsMounted]);
 
   const updateFiles = async (attachments: BlobFile[]) => {
-    const request = fetch(`/api/Request/Files/${projectId}`, {
+    const request = authenticatedFetch(`/api/Request/Files/${projectId}`, {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify({ Attachments: attachments }),
     });
 
@@ -82,12 +79,8 @@ export const ProjectDetailContainer = () => {
 
   //cancel the project
   const cancelProject = async () => {
-    const request = fetch(`/api/Request/Cancel/${projectId}`, {
+    const request = authenticatedFetch(`/api/Request/Cancel/${projectId}`, {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
     });
     setNotification(request, "Canceling", "Project Request Canceled");
     const response = await request;

--- a/Harvest.Web/ClientApp/src/Projects/ProjectFields.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectFields.tsx
@@ -5,6 +5,7 @@ import { Project } from "../types";
 import { getBoundingBox } from "../Util/Geography";
 import { LatLngBoundsExpression } from "leaflet";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 interface ProjectField {
   id: number;
@@ -22,7 +23,7 @@ export const ProjectFields = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const getFields = async () => {
-      const response = await fetch("/api/Project/GetFields");
+      const response = await authenticatedFetch("/api/Project/GetFields");
 
       if (response.ok) {
         const result = await response.json();

--- a/Harvest.Web/ClientApp/src/Projects/ProjectListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectListContainer.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { Project } from "../types";
 import { ProjectTable } from "./ProjectTable";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
@@ -30,7 +31,7 @@ export const ProjectListContainer = (props: Props) => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await fetch(props.projectSource);
+      const response = await authenticatedFetch(props.projectSource);
 
       if (response.ok) {
         getIsMounted() && setProjects(await response.json());

--- a/Harvest.Web/ClientApp/src/Projects/ProjectUnbilledButton.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectUnbilledButton.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { authenticatedFetch } from "../Util/Api";
 import { formatCurrency } from "../Util/NumberFormatting";
 import { useIsMounted } from "../Shared/UseIsMounted";
 
@@ -15,7 +16,7 @@ export const ProjectUnbilledButton = (props: Props) => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await fetch(
+      const response = await authenticatedFetch(
         `/api/expense/getunbilledtotal/${props.projectId}`
       );
 

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -16,6 +16,7 @@ import { ProjectHeader } from "../Shared/ProjectHeader";
 import { ActivitiesContainer } from "./ActivitiesContainer";
 import { QuoteTotals } from "./QuoteTotals";
 
+import { authenticatedFetch } from "../Util/Api";
 import { usePromiseNotification } from "../Util/Notifications";
 import { useInputValidator, ValidationProvider } from "use-input-validator";
 import { quoteContentSchema } from "../schemas";
@@ -53,8 +54,8 @@ export const QuoteContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const quoteResponse = await fetch(`/api/Quote/Get/${projectId}`);
-      const pricingResponse = await fetch("/api/Rate/Active");
+      const quoteResponse = await authenticatedFetch(`/api/Quote/Get/${projectId}`);
+      const pricingResponse = await authenticatedFetch("/api/Rate/Active");
 
       if (quoteResponse.ok && pricingResponse.ok) {
         const projectWithQuote: ProjectWithQuote = await quoteResponse.json();
@@ -203,12 +204,8 @@ export const QuoteContainer = () => {
       }
     }
 
-    const request = fetch(`/api/Quote/Save/${projectId}?submit=${submit}`, {
+    const request = authenticatedFetch(`/api/Quote/Save/${projectId}?submit=${submit}`, {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify(quote),
     });
 

--- a/Harvest.Web/ClientApp/src/Quotes/QuoteDisplayContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteDisplayContainer.tsx
@@ -4,6 +4,7 @@ import { useHistory, useParams } from "react-router-dom";
 import { ProjectWithQuote } from "../types";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { QuoteDisplay } from "./QuoteDisplay";
+import { authenticatedFetch } from "../Util/Api";
 import { formatCurrency } from "../Util/NumberFormatting";
 
 import { useIsMounted } from "../Shared/UseIsMounted";
@@ -23,7 +24,7 @@ export const QuoteDisplayContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const quoteResponse = await fetch(`/api/Quote/GetApproved/${projectId}`);
+      const quoteResponse = await authenticatedFetch(`/api/Quote/GetApproved/${projectId}`);
 
       if (quoteResponse.ok) {
         const projectWithQuote: ProjectWithQuote = await quoteResponse.json();

--- a/Harvest.Web/ClientApp/src/Quotes/RejectQuote.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/RejectQuote.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { Project } from "../types";
+import { authenticatedFetch } from "../Util/Api";
 import { usePromiseNotification } from "../Util/Notifications";
 import { useConfirmationDialog } from "../Shared/ConfirmationDialog";
 import { notEmptyOrFalsey } from "../Util/ValueChecks";
@@ -49,12 +50,8 @@ export const RejectQuote = (props: Props) => {
       return;
     }
 
-    const request = fetch(`/api/Request/RejectQuote/${props.project.id}`, {
+    const request = authenticatedFetch(`/api/Request/RejectQuote/${props.project.id}`, {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify({ reason }),
     });
 

--- a/Harvest.Web/ClientApp/src/Requests/AccountChangeContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/AccountChangeContainer.tsx
@@ -4,6 +4,7 @@ import { useHistory, useParams } from "react-router-dom";
 import { Project, ProjectAccount } from "../types";
 import { AccountsInput } from "./AccountsInput";
 import { ProjectHeader } from "../Shared/ProjectHeader";
+import { authenticatedFetch } from "../Util/Api";
 import { usePromiseNotification } from "../Util/Notifications";
 import { useIsMounted } from "../Shared/UseIsMounted";
 
@@ -23,7 +24,7 @@ export const AccountChangeContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
@@ -41,12 +42,8 @@ export const AccountChangeContainer = () => {
 
   //TODO: require PI or supervisor access after updating auth policies
   const changeAccounts = async () => {
-    const request = fetch(`/api/Request/ChangeAccount/${projectId}`, {
+    const request = authenticatedFetch(`/api/Request/ChangeAccount/${projectId}`, {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify({ Accounts: accounts }),
     });
 

--- a/Harvest.Web/ClientApp/src/Requests/AccountsInput.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/AccountsInput.tsx
@@ -10,6 +10,7 @@ import { ProjectAccount } from "../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinusCircle } from "@fortawesome/free-solid-svg-icons";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 interface Props {
   accounts: ProjectAccount[];
@@ -56,7 +57,7 @@ export const AccountsInput = (props: Props) => {
   const onSearch = async (query: string) => {
     setIsSearchLoading(true);
 
-    const response = await fetch(`/api/financialaccount/get?account=${query}`);
+    const response = await authenticatedFetch(`/api/financialaccount/get?account=${query}`);
 
     if (response.ok) {
       if (response.status === 204) {

--- a/Harvest.Web/ClientApp/src/Requests/ApprovalContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/ApprovalContainer.tsx
@@ -8,6 +8,7 @@ import { QuoteDisplay } from "../Quotes/QuoteDisplay";
 import { RejectQuote } from "../Quotes/RejectQuote";
 import { formatCurrency } from "../Util/NumberFormatting";
 
+import { authenticatedFetch } from "../Util/Api";
 import { usePromiseNotification } from "../Util/Notifications";
 import { useIsMounted } from "../Shared/UseIsMounted";
 
@@ -30,7 +31,7 @@ export const ApprovalContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const quoteResponse = await fetch(`/api/Quote/Get/${projectId}`);
+      const quoteResponse = await authenticatedFetch(`/api/Quote/Get/${projectId}`);
 
       if (quoteResponse.ok) {
         const projectWithQuote: ProjectWithQuote = await quoteResponse.json();
@@ -50,12 +51,8 @@ export const ApprovalContainer = () => {
   const approve = async () => {
     const model = { accounts };
 
-    const request = fetch(`/api/Request/Approve/${projectId}`, {
+    const request = authenticatedFetch(`/api/Request/Approve/${projectId}`, {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify(model),
     });
 

--- a/Harvest.Web/ClientApp/src/Requests/Crops.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/Crops.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { Typeahead, TypeaheadProps } from "react-bootstrap-typeahead";
 import { Crop, CropType } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 interface Props extends Pick<TypeaheadProps<string>, "onBlur"> {
   crops: string;
@@ -41,7 +42,7 @@ export const Crops = (props: Props) => {
     const onSearch = async () => {
       setIsSearchLoading(true);
 
-      const response = await fetch(`/api/Crop/Search?type=${props.cropType}`);
+      const response = await authenticatedFetch(`/api/Crop/Search?type=${props.cropType}`);
 
       if (response.ok) {
         if (response.status === 204) {

--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
@@ -13,6 +13,7 @@ import AppContext from "../Shared/AppContext";
 import { usePromiseNotification } from "../Util/Notifications";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 import { useInputValidator, ValidationProvider } from "use-input-validator";
 import { validatorOptions } from "../constants";
 
@@ -51,7 +52,7 @@ export const RequestContainer = () => {
   useEffect(() => {
     // load original request if this is a change request
     const cb = async () => {
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
@@ -82,12 +83,8 @@ export const RequestContainer = () => {
       return;
     }
 
-    const request = fetch(`/api/Request/Create`, {
+    const request = authenticatedFetch(`/api/Request/Create`, {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify(project),
     });
 

--- a/Harvest.Web/ClientApp/src/Requests/SearchPerson.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/SearchPerson.tsx
@@ -7,6 +7,7 @@ import {
   TypeaheadProps,
 } from "react-bootstrap-typeahead";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 import { User } from "../types";
 
@@ -23,7 +24,7 @@ export const SearchPerson = (props: Props) => {
   const onSearch = async (query: string) => {
     setIsSearchLoading(true);
 
-    const response = await fetch(`/api/people/search?query=${query}`);
+    const response = await authenticatedFetch(`/api/people/search?query=${query}`);
 
     if (response.ok) {
       if (response.status === 204) {

--- a/Harvest.Web/ClientApp/src/Shared/AppContext.ts
+++ b/Harvest.Web/ClientApp/src/Shared/AppContext.ts
@@ -2,6 +2,7 @@ import React from "react";
 import { AppContextShape, User } from "../types";
 
 const AppContext = React.createContext<AppContextShape>({
+  antiForgeryToken: "",
   user: { detail: {} as User, roles: [] },
 });
 

--- a/Harvest.Web/ClientApp/src/Shared/FileUpload.tsx
+++ b/Harvest.Web/ClientApp/src/Shared/FileUpload.tsx
@@ -6,6 +6,7 @@ import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { BlobServiceClient } from "@azure/storage-blob";
 import { BlobFile } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 interface Props {
   disabled?: boolean;
@@ -44,7 +45,7 @@ export const FileUpload = (props: Props) => {
   useEffect(() => {
     // grab the sas token right away
     const cb = async () => {
-      const response = await fetch(`/api/File/GetUploadDetails`);
+      const response = await authenticatedFetch(`/api/File/GetUploadDetails`);
 
       if (response.ok) {
         const url = await response.text();

--- a/Harvest.Web/ClientApp/src/Test/mockData.ts
+++ b/Harvest.Web/ClientApp/src/Test/mockData.ts
@@ -39,6 +39,7 @@ const fakeAttachments: BlobFile[] = [
 ];
 
 export const fakeAppContext: AppContextShape = {
+  antiForgeryToken: "fakeAntiForgeryToken",
   user: {
     detail: {
       ...fakeUser,

--- a/Harvest.Web/ClientApp/src/Tickets/RecentTicketsContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/RecentTicketsContainer.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { Ticket } from "../types";
 import { TicketTable } from "./TicketTable";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 interface Props {
   projectId?: string;
@@ -17,7 +18,7 @@ export const RecentTicketsContainer = (props: Props) => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(
+      const response = await authenticatedFetch(
         `/api/Ticket/GetList?projectId=${props.projectId}&maxRows=${maxRows}`
       );
 

--- a/Harvest.Web/ClientApp/src/Tickets/TicketAttachments.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketAttachments.tsx
@@ -4,6 +4,7 @@ import { faDownload } from "@fortawesome/free-solid-svg-icons";
 import { TicketAttachment, TicketDetails, BlobFile } from "../types";
 import { FormGroup, Label } from "reactstrap";
 import { FileUpload } from "../Shared/FileUpload";
+import { authenticatedFetch } from "../Util/Api";
 import { usePromiseNotification } from "../Util/Notifications";
 import { useIsMounted } from "../Shared/UseIsMounted";
 
@@ -28,14 +29,10 @@ export const TicketAttachments = (props: Props) => {
 
   const getIsMounted = useIsMounted();
   const updateFiles = async (attachments: BlobFile[]) => {
-    const request = fetch(
+    const request = authenticatedFetch(
       `/api/Ticket/UploadFiles/${projectId}/${props.ticket.id}/`,
       {
         method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
         body: JSON.stringify({ Attachments: attachments }),
       }
     );

--- a/Harvest.Web/ClientApp/src/Tickets/TicketCreate.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketCreate.tsx
@@ -7,6 +7,7 @@ import { Button, FormGroup, Input, Label } from "reactstrap";
 import { FileUpload } from "../Shared/FileUpload";
 import { ShowFor } from "../Shared/ShowFor";
 import { ticketSchema } from "../schemas";
+import { authenticatedFetch } from "../Util/Api";
 import { usePromiseNotification } from "../Util/Notifications";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { useInputValidator } from "use-input-validator";
@@ -42,7 +43,7 @@ export const TicketCreate = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
@@ -67,12 +68,8 @@ export const TicketCreate = () => {
       return;
     }
 
-    const request = fetch(`/api/Ticket/Create?projectId=${projectId}`, {
+    const request = authenticatedFetch(`/api/Ticket/Create?projectId=${projectId}`, {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify(ticket),
     });
     setNotification(request, "Creating Ticket", "Ticket Created");

--- a/Harvest.Web/ClientApp/src/Tickets/TicketDetailContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketDetailContainer.tsx
@@ -8,6 +8,7 @@ import { ShowFor } from "../Shared/ShowFor";
 import { TicketWorkNotesEdit } from "./TicketWorkNotesEdit";
 import { TicketReply } from "./TicketReply";
 import { Button } from "reactstrap";
+import { authenticatedFetch } from "../Util/Api";
 import { usePromiseNotification } from "../Util/Notifications";
 import { useIsMounted } from "../Shared/UseIsMounted";
 
@@ -27,7 +28,7 @@ export const TicketDetailContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
@@ -40,7 +41,7 @@ export const TicketDetailContainer = () => {
 
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/api/Ticket/Get/${projectId}/${ticketId}`);
+      const response = await authenticatedFetch(`/api/Ticket/Get/${projectId}/${ticketId}`);
 
       if (response.ok) {
         const tick: TicketDetails = await response.json();
@@ -56,14 +57,10 @@ export const TicketDetailContainer = () => {
   }
 
   const closeTicket = async () => {
-    const request = fetch(
+    const request = authenticatedFetch(
       `/api/Ticket/Close?projectId=${projectId}&ticketId=${ticketId}`,
       {
         method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
       }
     );
     setNotification(request, "Closing Ticket", "Ticket Closed");

--- a/Harvest.Web/ClientApp/src/Tickets/TicketListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketListContainer.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { Ticket } from "../types";
 import { TicketTable } from "./TicketTable";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 interface Props {
   projectSource: string;
@@ -15,7 +16,7 @@ export const TicketListContainer = (props: Props) => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await fetch(props.projectSource);
+      const response = await authenticatedFetch(props.projectSource);
 
       if (response.ok) {
         getIsMounted() && setTickets(await response.json());

--- a/Harvest.Web/ClientApp/src/Tickets/TicketReply.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketReply.tsx
@@ -1,6 +1,7 @@
 ﻿import React, { useState } from "react";
 import { Button, FormGroup, Input } from "reactstrap";
 import { TicketDetails, TicketMessage } from "../types";
+import { authenticatedFetch } from "../Util/Api";
 import { usePromiseNotification } from "../Util/Notifications";
 import { useIsMounted } from "../Shared/UseIsMounted";
 
@@ -22,14 +23,10 @@ export const TicketReply = (props: Props) => {
   const update = async () => {
     // TODO: validation
 
-    const request = fetch(
+    const request = authenticatedFetch(
       `/api/Ticket/Reply?projectId=${projectId}&ticketId=${ticket.id}`,
       {
         method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
         body: JSON.stringify(ticketMessage),
       }
     );

--- a/Harvest.Web/ClientApp/src/Tickets/TicketWorkNotesEdit.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketWorkNotesEdit.tsx
@@ -1,5 +1,6 @@
 ﻿import { TicketDetails } from "../types";
 import { Button, FormGroup, Input } from "reactstrap";
+import { authenticatedFetch } from "../Util/Api";
 import { usePromiseNotification } from "../Util/Notifications";
 
 interface Props {
@@ -16,14 +17,10 @@ export const TicketWorkNotesEdit = (props: Props) => {
   const update = async () => {
     // TODO: validation
 
-    const request = fetch(
+    const request = authenticatedFetch(
       `/api/Ticket/UpdateWorkNotes?projectId=${props.projectId}&ticketId=${ticket.id}`,
       {
         method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
         body: JSON.stringify(ticket.workNotes),
       }
     );

--- a/Harvest.Web/ClientApp/src/Tickets/TicketsContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketsContainer.tsx
@@ -4,6 +4,7 @@ import { Project, Ticket } from "../types";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { TicketTable } from "./TicketTable";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { authenticatedFetch } from "../Util/Api";
 
 interface RouteParams {
   projectId?: string;
@@ -17,7 +18,7 @@ export const TicketsContainer = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
 
       if (response.ok) {
         const proj: Project = await response.json();
@@ -30,7 +31,7 @@ export const TicketsContainer = () => {
 
   useEffect(() => {
     const cb = async () => {
-      const response = await fetch(`/api/Ticket/GetList?projectId=${projectId}`);
+      const response = await authenticatedFetch(`/api/Ticket/GetList?projectId=${projectId}`);
 
       if (response.ok) {
         getIsMounted() && setTickets(await response.json());

--- a/Harvest.Web/ClientApp/src/Util/Api.ts
+++ b/Harvest.Web/ClientApp/src/Util/Api.ts
@@ -1,0 +1,17 @@
+import { AppContextShape } from "../types";
+
+declare var Harvest: AppContextShape;
+
+export const authenticatedFetch = async (
+  url: string,
+  init?: RequestInit
+): Promise<any> =>
+  fetch(url, {
+    ...init,
+    credentials: "include",
+    headers: [
+      ["Accept", "application/json"],
+      ["Content-Type", "application/json"],
+      ["RequestVerificationToken", Harvest.antiForgeryToken],
+    ],
+  });

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -347,6 +347,7 @@ export interface ProjectWithInvoice {
 }
 
 export interface AppContextShape {
+  antiForgeryToken: string;
   user: {
     detail: User;
     roles: RoleName[];

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -13,7 +13,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Harvest.Web.Controllers.Api
 {
     [Authorize]
-    public class ExpenseController : Controller
+    public class ExpenseController : SuperController
     {
         private readonly AppDbContext _dbContext;
         private readonly IUserService _userService;

--- a/Harvest.Web/Controllers/Api/FieldController.cs
+++ b/Harvest.Web/Controllers/Api/FieldController.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Harvest.Web.Controllers.Api
 {
     [Authorize(Policy = AccessCodes.SupervisorAccess)]
-    public class FieldController : Controller
+    public class FieldController : SuperController
     {
         private AppDbContext _dbContext;
 

--- a/Harvest.Web/Controllers/Api/FileController.cs
+++ b/Harvest.Web/Controllers/Api/FileController.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace Harvest.Web.Controllers.Api
 {
     [Authorize]
-    public class FileController : Controller
+    public class FileController : SuperController
     {
         private readonly StorageSettings storageSettings;
         private readonly IFileService fileService;

--- a/Harvest.Web/Controllers/Api/FinancialAccountController.cs
+++ b/Harvest.Web/Controllers/Api/FinancialAccountController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Harvest.Web.Controllers.Api
 {
     [Authorize]
-    public class FinancialAccountController : Controller
+    public class FinancialAccountController : SuperController
     {
         private readonly AppDbContext _dbContext;
         private readonly IFinancialService _financialService;

--- a/Harvest.Web/Controllers/Api/InvoiceController.cs
+++ b/Harvest.Web/Controllers/Api/InvoiceController.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Harvest.Web.Controllers.Api
 {
     [Authorize(Policy = AccessCodes.PrincipalInvestigator)]
-    public class InvoiceController : Controller
+    public class InvoiceController : SuperController
     {
         private readonly AppDbContext _dbContext;
         private readonly IUserService _userService;

--- a/Harvest.Web/Controllers/Api/PeopleController.cs
+++ b/Harvest.Web/Controllers/Api/PeopleController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Harvest.Web.Controllers.Api
 {
     [Authorize()]
-    public class PeopleController : Controller
+    public class PeopleController : SuperController
     {
         private readonly AppDbContext _dbContext;
         private readonly IIdentityService _identityService;

--- a/Harvest.Web/Controllers/Api/PingController.cs
+++ b/Harvest.Web/Controllers/Api/PingController.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace Harvest.Web.Controllers.Api
 {
 
-    public class PingController : Controller
+    public class PingController : SuperController
     {
         private readonly AppDbContext _dbContext;
 

--- a/Harvest.Web/Controllers/Api/QuoteController.cs
+++ b/Harvest.Web/Controllers/Api/QuoteController.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Harvest.Web.Controllers.Api
 {
     [Authorize(Policy = AccessCodes.PrincipalInvestigator)]
-    public class QuoteController : Controller
+    public class QuoteController : SuperController
     {
         private readonly AppDbContext _dbContext;
         private readonly IUserService _userService;

--- a/Harvest.Web/Controllers/Api/RequestController.cs
+++ b/Harvest.Web/Controllers/Api/RequestController.cs
@@ -17,7 +17,7 @@ using NetTopologySuite.Geometries;
 namespace Harvest.Web.Controllers.Api
 {
     [Authorize]
-    public class RequestController : Controller
+    public class RequestController : SuperController
     {
         private readonly AppDbContext _dbContext;
         private readonly IUserService _userService;

--- a/Harvest.Web/Controllers/Api/TicketController.cs
+++ b/Harvest.Web/Controllers/Api/TicketController.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Options;
 namespace Harvest.Web.Controllers.Api
 {
     [Authorize]
-    public class TicketController : Controller
+    public class TicketController : SuperController
     {
         private readonly AppDbContext _dbContext;
         private readonly IUserService _userService;

--- a/Harvest.Web/Views/Shared/_Layout.cshtml
+++ b/Harvest.Web/Views/Shared/_Layout.cshtml
@@ -2,6 +2,8 @@
 @using Harvest.Core.Services
 @inject IConfiguration Configuration
 @inject IUserService UserService
+@inject Microsoft.AspNetCore.Antiforgery.IAntiforgery Xsrf
+
 <!DOCTYPE html>
 <html>
 
@@ -73,6 +75,7 @@
         var Harvest = { user: {} };
         Harvest.user.detail = @Html.Raw(Context.GetUserDetails());
         Harvest.user.roles = @Html.Raw(await Context.GetUserRoles());
+        Harvest.antiForgeryToken = "@Xsrf.GetAndStoreTokens(Context).RequestToken";
     </script>
 
     <environment include="Development">

--- a/Test/TestsControllers/TestsApiControllers/ExpenseControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/ExpenseControllerTests.cs
@@ -32,13 +32,13 @@ namespace Test.TestsControllers.TestsApiControllers
         [Fact]
         public void TestControllerClassAttributes()
         {
-            ControllerReflection.ControllerInherits("Controller");
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
-            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(2, showListOfAttributes: true);
+            ControllerReflection.ControllerInherits("SuperController");
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3, showListOfAttributes: true);
+            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(3, showListOfAttributes: true);
             attributes.ElementAt(0).Policy.ShouldBeNull();
 
-            //ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3);
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
         }
 
         [Fact]

--- a/Test/TestsControllers/TestsApiControllers/FieldControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/FieldControllerTests.cs
@@ -31,13 +31,13 @@ namespace Test.TestsControllers.TestsApiControllers
         [Fact]
         public void TestControllerClassAttributes()
         {
-            ControllerReflection.ControllerInherits("Controller");
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
-            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(2, showListOfAttributes: true);
+            ControllerReflection.ControllerInherits("SuperController");
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
+            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(3, showListOfAttributes: true);
             attributes.ElementAt(0).Policy.ShouldBe(AccessCodes.SupervisorAccess);
 
-            //ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); 
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
         }
 
         [Fact]

--- a/Test/TestsControllers/TestsApiControllers/FileControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/FileControllerTests.cs
@@ -29,12 +29,12 @@ namespace Test.TestsControllers.TestsApiControllers
         [Fact]
         public void TestControllerClassAttributes()
         {
-            ControllerReflection.ControllerInherits("Controller");
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
-            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(2, showListOfAttributes: true);
+            ControllerReflection.ControllerInherits("SuperController");
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
+            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(3, showListOfAttributes: true);
             attributes.ElementAt(0).Policy.ShouldBeNull();
-            //ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
         }
 
         [Fact]

--- a/Test/TestsControllers/TestsApiControllers/FinancialAccountControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/FinancialAccountControllerTests.cs
@@ -30,12 +30,12 @@ namespace Test.TestsControllers.TestsApiControllers
         [Fact]
         public void TestControllerClassAttributes()
         {
-            ControllerReflection.ControllerInherits("Controller");
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
-            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(2, showListOfAttributes: true);
+            ControllerReflection.ControllerInherits("SuperController");
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
+            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(3, showListOfAttributes: true);
             attributes.ElementAt(0).Policy.ShouldBeNull();
-            //ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
         }
 
         [Fact]

--- a/Test/TestsControllers/TestsApiControllers/InvoiceControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/InvoiceControllerTests.cs
@@ -31,12 +31,12 @@ namespace Test.TestsControllers.TestsApiControllers
         [Fact]
         public void TestControllerClassAttributes()
         {
-            ControllerReflection.ControllerInherits("Controller");
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
-            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(2, showListOfAttributes: true);
+            ControllerReflection.ControllerInherits("SuperController");
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
+            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(3, showListOfAttributes: true);
             attributes.ElementAt(0).Policy.ShouldBe(AccessCodes.PrincipalInvestigator);
-            //ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
         }
 
         [Fact]

--- a/Test/TestsControllers/TestsApiControllers/PeopleControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/PeopleControllerTests.cs
@@ -31,12 +31,12 @@ namespace Test.TestsControllers.TestsApiControllers
         [Fact]
         public void TestControllerClassAttributes()
         {
-            ControllerReflection.ControllerInherits("Controller");
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
-            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(2, showListOfAttributes: true);
+            ControllerReflection.ControllerInherits("SuperController");
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
+            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(3, showListOfAttributes: true);
             attributes.ElementAt(0).Policy.ShouldBeNull();
-            //ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
         }
 
         [Fact]

--- a/Test/TestsControllers/TestsApiControllers/QuoteControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/QuoteControllerTests.cs
@@ -31,12 +31,12 @@ namespace Test.TestsControllers.TestsApiControllers
         [Fact]
         public void TestControllerClassAttributes()
         {
-            ControllerReflection.ControllerInherits("Controller");
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
-            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(2, showListOfAttributes: true);
+            ControllerReflection.ControllerInherits("SuperController");
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
+            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(3, showListOfAttributes: true);
             attributes.ElementAt(0).Policy.ShouldBe(AccessCodes.PrincipalInvestigator);
-            //ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
         }
 
         [Fact]

--- a/Test/TestsControllers/TestsApiControllers/RequestControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/RequestControllerTests.cs
@@ -31,12 +31,12 @@ namespace Test.TestsControllers.TestsApiControllers
         [Fact]
         public void TestControllerClassAttributes()
         {
-            ControllerReflection.ControllerInherits("Controller");
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
-            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(2, showListOfAttributes: true);
+            ControllerReflection.ControllerInherits("SuperController");
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
+            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(3, showListOfAttributes: true);
             attributes.ElementAt(0).Policy.ShouldBeNull();
-            //ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
         }
 
         [Fact]

--- a/Test/TestsControllers/TestsApiControllers/TicketControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/TicketControllerTests.cs
@@ -31,12 +31,12 @@ namespace Test.TestsControllers.TestsApiControllers
         [Fact]
         public void TestControllerClassAttributes()
         {
-            ControllerReflection.ControllerInherits("Controller");
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
-            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(2, showListOfAttributes: true);
+            ControllerReflection.ControllerInherits("SuperController");
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
+            var attributes = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(3, showListOfAttributes: true);
             attributes.ElementAt(0).Policy.ShouldBeNull();
-            //ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(2);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenAttribute>(3); //TODO: Enable when this gets added.
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(3);
         }
 
         [Fact]


### PR DESCRIPTION
Updated all API controllers to inherit from SuperController, which means they are now behind `[AutoValidateAntiforgeryToken]`.  I then injected the token into the Layout.cshtml page and read it into react as part of our `Harvest` var just like user info.  Next I made a simple wrapper around `fetch()` with `authenticatedFetch()` and you need to use that for any non-GET method, though it's cleaner to just try to remember to use it everywhere you would have done fetch.  Similar idea to peaks except I didn't attach the new fetch stand-in to `context` which I think keeps it cleaner and more flexible.

One thing to note - the new `authenticatedFetch()` assumes a JSON payload accepting a JSON response.  AFAIK we use this for every fetch, but if in the future we have a reason to do something else we'll need to tweak it to allow header overrides or to directly expose the token or by some other means.  Probably won't come up but just in case....

closes #555