### PR TITLE
Team routes for project & expenses

### DIFF
--- a/Harvest.Core/Extensions/HttpContextExtensions.cs
+++ b/Harvest.Core/Extensions/HttpContextExtensions.cs
@@ -26,5 +26,16 @@ namespace Harvest.Core.Extensions
 
             return null;
         }
+        
+        public static string GetTeam(this IHttpContextAccessor httpContextAccessor)
+        {
+            var httpContext = httpContextAccessor.HttpContext;
+            if (httpContext == null)
+            {
+                return null;
+            }
+
+            return (string)httpContext.Request.Query["team"] ?? httpContext.GetRouteValue("team") as string;
+        }
     }
 }

--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -108,35 +108,38 @@ function App() {
               path="/project/closeoutconfirmation/:projectId"
               component={CloseoutConfirmationContainer}
             />
+            <ConditionalRoute exact roles={["PI"]} path="/project/mine">
+              <ProjectListContainer projectSource="/api/Project/GetMine" />
+            </ConditionalRoute>
+            
+            <ConditionalRoute
+                roles={["FieldManager", "Supervisor", "PI"]}
+                path="/ticket/create/:projectId"
+                component={TicketCreate}
+            />
+            
+            {/* admin routes requiring team context */}
             <ConditionalRoute
               exact
               roles={["FieldManager", "Supervisor"]}
-              path="/project"
+              path=":team/project"
             >
               <ProjectListContainer projectSource="/api/Project/All" />
             </ConditionalRoute>
             <ConditionalRoute
               exact
               roles={["FieldManager", "Supervisor"]}
-              path="/project/needsAttention"
+              path=":team/project/needsAttention"
             >
               <ProjectListContainer projectSource="/api/Project/RequiringManagerAttention" />
             </ConditionalRoute>
             <ConditionalRoute
               exact
               roles={["FieldManager", "Supervisor"]}
-              path="/project/completed"
+              path=":team/project/completed"
             >
               <ProjectListContainer projectSource="/api/Project/GetCompleted" />
             </ConditionalRoute>
-            <ConditionalRoute exact roles={["PI"]} path="/project/mine">
-              <ProjectListContainer projectSource="/api/Project/GetMine" />
-            </ConditionalRoute>
-            <ConditionalRoute
-              roles={["FieldManager", "Supervisor", "PI"]}
-              path="/ticket/create/:projectId"
-              component={TicketCreate}
-            />
             <ConditionalRoute
               exact
               roles={["FieldManager", "Supervisor"]}

--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -29,7 +29,7 @@ import { TicketDetailContainer } from "./Tickets/TicketDetailContainer";
 import { CloseoutContainer } from "./Closeout/CloseoutContainer";
 import { CloseoutConfirmationContainer } from "./Closeout/CloseoutConfirmationContainer";
 import { AdhocProject } from "./Projects/AdhocProject";
-import {TeamPicker} from "./Teams/TeamPicker";
+import { TeamPicker } from "./Teams/TeamPicker";
 
 // Global variable containing top-level app settings and info
 declare var Harvest: AppContextShape;
@@ -54,11 +54,7 @@ function App() {
             <Route exact path="/:team/team/" component={HomeContainer} />
 
             {/* Creating a new request requires first picking a team */}
-            <Route
-                exact
-                path="/request/create/"
-                component={TeamPicker}
-            />
+            <Route exact path="/request/create/" component={TeamPicker} />
             <Route
               exact
               path="/:team/request/create/:projectId?"
@@ -111,32 +107,32 @@ function App() {
             <ConditionalRoute exact roles={["PI"]} path="/project/mine">
               <ProjectListContainer projectSource="/api/Project/GetMine" />
             </ConditionalRoute>
-            
+
             <ConditionalRoute
-                roles={["FieldManager", "Supervisor", "PI"]}
-                path="/ticket/create/:projectId"
-                component={TicketCreate}
+              roles={["FieldManager", "Supervisor", "PI"]}
+              path="/ticket/create/:projectId"
+              component={TicketCreate}
             />
-            
+
             {/* admin routes requiring team context */}
             <ConditionalRoute
               exact
               roles={["FieldManager", "Supervisor"]}
-              path=":team/project"
+              path="/:team/project"
             >
               <ProjectListContainer projectSource="/api/Project/All" />
             </ConditionalRoute>
             <ConditionalRoute
               exact
               roles={["FieldManager", "Supervisor"]}
-              path=":team/project/needsAttention"
+              path="/:team/project/needsAttention"
             >
               <ProjectListContainer projectSource="/api/Project/RequiringManagerAttention" />
             </ConditionalRoute>
             <ConditionalRoute
               exact
               roles={["FieldManager", "Supervisor"]}
-              path=":team/project/completed"
+              path="/:team/project/completed"
             >
               <ProjectListContainer projectSource="/api/Project/GetCompleted" />
             </ConditionalRoute>

--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -43,10 +43,13 @@ function App() {
         <main role="main" className="main-content-wrapper container">
           <Switch>
             {/* Match any server-side routes and send empty content to let MVC return the view details */}
+            <Route path="/:team/(rate|permissions)" component={Empty} />
             <Route
-              path="/(account|rate|permissions|crop|home|system|help|report)"
+              path="/(account|crop|home|system|help|report)"
               component={Empty}
             />
+
+            {/* Home route */}
             <Route exact path="/" component={HomeContainer} />
 
             {/* Visitors with non-PI roles will require selecting a team */}

--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -139,7 +139,7 @@ function App() {
             <ConditionalRoute
               exact
               roles={["FieldManager", "Supervisor"]}
-              path="/ticket/needsAttention"
+              path="/:team/ticket/needsAttention"
             >
               <TicketListContainer projectSource="/api/ticket/RequiringManagerAttention" />
             </ConditionalRoute>
@@ -157,6 +157,11 @@ function App() {
             <Route
               path="/project/details/:projectId"
               component={ProjectDetailContainer}
+            />
+            <ConditionalRoute
+              roles={["FieldManager", "Supervisor", "Worker"]}
+              path="/:team/expense/entry/"
+              component={ExpenseEntryContainer}
             />
             <ConditionalRoute
               roles={["FieldManager", "Supervisor", "Worker"]}

--- a/Harvest.Web/ClientApp/src/AppNav.tsx
+++ b/Harvest.Web/ClientApp/src/AppNav.tsx
@@ -13,10 +13,30 @@ import {
   DropdownItem,
 } from "reactstrap";
 import AppContext from "./Shared/AppContext";
+import { useParams } from "react-router";
+import { useLocation } from "react-router-dom";
+
+const getTeam = (pathName: string) => {
+  // return the first path token in the pathName
+  if (!pathName) {
+    return "";
+  } else {
+    const pathSegments = pathName.split("/");
+
+    if (pathSegments.length > 1) {
+      return pathSegments[1];
+    } else {
+      return "";
+    }
+  }
+};
 
 export const AppNav = () => {
   const user = useContext(AppContext).user;
   const [isOpen, setIsOpen] = useState(false);
+
+  const location = useLocation();
+  const team = getTeam(location.pathname);
 
   const toggle = () => setIsOpen(!isOpen);
 
@@ -29,7 +49,7 @@ export const AppNav = () => {
             <Nav navbar>
               <ShowFor roles={["FieldManager", "Supervisor"]}>
                 <NavItem>
-                  <NavLink href="/project">All Projects</NavLink>
+                  <NavLink href={`/${team}/project`}>All Projects</NavLink>
                 </NavItem>
               </ShowFor>
               <ShowFor roles={["PI"]}>
@@ -39,7 +59,7 @@ export const AppNav = () => {
               </ShowFor>
               <ShowFor roles={["FieldManager", "Supervisor", "Worker"]}>
                 <NavItem>
-                  <NavLink href="/expense/entry">Expenses</NavLink>
+                  <NavLink href={`/${team}/expense/entry`}>Expenses</NavLink>
                 </NavItem>
               </ShowFor>
               <ShowFor roles={["FieldManager", "Supervisor"]}>
@@ -49,42 +69,46 @@ export const AppNav = () => {
                   </DropdownToggle>
                   <DropdownMenu right>
                     <ShowFor roles={["FieldManager"]}>
-                      <DropdownItem href="/Permissions/Index">
+                      <DropdownItem href={`/${team}/Permissions/Index`}>
                         Permissions
                       </DropdownItem>
                     </ShowFor>
-                    <DropdownItem href="/Rate/Index">Rates</DropdownItem>
+                    <DropdownItem href={`/${team}/Rate/Index`}>
+                      Rates
+                    </DropdownItem>
                     <ShowFor roles={["FieldManager"]}>
-                      <DropdownItem href="/Crop/Index">Crops</DropdownItem>
+                      <DropdownItem href={`/${team}/Crop/Index`}>
+                        Crops
+                      </DropdownItem>
                     </ShowFor>
                     <ShowFor roles={["FieldManager"]}>
                       <DropdownItem divider />
-                      <DropdownItem href="/project/adhocproject">
+                      <DropdownItem href={`/${team}/project/adhocproject`}>
                         Ad-Hoc Project
                       </DropdownItem>
                     </ShowFor>
                     <DropdownItem divider />
-                    <DropdownItem href="/Project/Completed">
+                    <DropdownItem href={`/${team}/Project/Completed`}>
                       Completed Projects
                     </DropdownItem>
-                    <DropdownItem href="/Project/NeedsAttention">
+                    <DropdownItem href={`/${team}/Project/NeedsAttention`}>
                       Projects Needing Attention
                     </DropdownItem>
-                    <DropdownItem href="/Ticket/NeedsAttention">
+                    <DropdownItem href={`/${team}/Ticket/NeedsAttention`}>
                       Open Tickets
                     </DropdownItem>
                     <ShowFor roles={["System"]}>
                       <DropdownItem divider />
-                      <DropdownItem href="/System/UpdatePendingExpenses">
+                      <DropdownItem href={`/System/UpdatePendingExpenses`}>
                         Unprocessed Expenses
                       </DropdownItem>
-                      <DropdownItem href="/System/Emulate">
+                      <DropdownItem href={`/System/Emulate`}>
                         Emulate
                       </DropdownItem>
-                      <DropdownItem href="/Report/AllProjects">
+                      <DropdownItem href={`/Report/AllProjects`}>
                         Reports - Projects
                       </DropdownItem>
-                      <DropdownItem href="/Report/HistoricalRateActivity">
+                      <DropdownItem href={`/Report/HistoricalRateActivity`}>
                         Reports - Historical Rate Activity
                       </DropdownItem>
                     </ShowFor>
@@ -93,7 +117,7 @@ export const AppNav = () => {
               </ShowFor>
 
               <NavItem>
-                <NavLink href="/Help">Help</NavLink>
+                <NavLink href={`/Help`}>Help</NavLink>
               </NavItem>
             </Nav>
             <div className="d-flex align-items-center user-sign-in">

--- a/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
@@ -33,6 +33,7 @@ import { convertCamelCase } from "../Util/StringFormatting";
 
 interface RouteParams {
   projectId?: string;
+  team?: string;
 }
 
 const getDefaultActivity = (id: number) => ({
@@ -51,7 +52,7 @@ const getDefaultActivity = (id: number) => ({
 export const ExpenseEntryContainer = () => {
   const history = useHistory();
 
-  const { projectId } = useParams<RouteParams>();
+  const { projectId, team } = useParams<RouteParams>();
   const [rates, setRates] = useState<Rate[]>([]);
   const [inputErrors, setInputErrors] = useState<string[]>([]);
   const context = useOrCreateValidationContext(validatorOptions);
@@ -85,7 +86,9 @@ export const ExpenseEntryContainer = () => {
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await authenticatedFetch("/api/Rate/Active");
+      const response = await authenticatedFetch(
+        `/api/Rate/Active?team=${team}`
+      );
 
       if (response.ok) {
         const rates: Rate[] = await response.json();
@@ -102,7 +105,9 @@ export const ExpenseEntryContainer = () => {
   useEffect(() => {
     // get project in order to determine if it can accept new expenses
     const cb = async () => {
-      const response = await authenticatedFetch(`/api/Project/Get/${projectId}`);
+      const response = await authenticatedFetch(
+        `/api/Project/Get/${projectId}`
+      );
 
       if (response.ok) {
         const project = (await response.json()) as Project;

--- a/Harvest.Web/ClientApp/src/Expenses/ProjectSelection.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ProjectSelection.tsx
@@ -5,6 +5,11 @@ import { FormGroup, Input } from "reactstrap";
 import { Project } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { authenticatedFetch } from "../Util/Api";
+import { useParams } from "react-router-dom";
+
+interface RouteParams {
+  team?: string;
+}
 
 interface Props {
   selectedProject: (projectId: number) => void;
@@ -13,11 +18,15 @@ interface Props {
 export const ProjectSelection = (props: Props) => {
   const [projects, setProjects] = useState<Project[]>();
 
+  const { team } = useParams<RouteParams>();
+
   const getIsMounted = useIsMounted();
   useEffect(() => {
     // get list of projects
     const cb = async () => {
-      const response = await authenticatedFetch(`/api/Project/Active`);
+      const response = await authenticatedFetch(
+        `/api/Project/Active?team=${team}`
+      );
 
       if (response.ok) {
         const projects = await response.json();

--- a/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
@@ -1,20 +1,30 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, Redirect } from "react-router-dom";
 
 import { authenticatedFetch } from "../Util/Api";
 import { StatusToActionRequired } from "../Util/MessageHelpers";
 import { Project, Ticket } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { useParams } from "react-router";
+
+interface RouteParams {
+  team?: string;
+}
 
 export const FieldManagerHome = () => {
   const [projects, setProjects] = useState<Project[]>([]);
   const [tickets, setTickets] = useState<Ticket[]>([]);
 
+  const { team } = useParams<RouteParams>();
+
   const getIsMounted = useIsMounted();
+
   useEffect(() => {
     // get info on projects requiring approval
     const getProjects = async () => {
-      const response = await authenticatedFetch("/api/project/RequiringManagerAttention");
+      const response = await authenticatedFetch(
+        `/api/project/RequiringManagerAttention?team=${team}`
+      );
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);
@@ -27,7 +37,7 @@ export const FieldManagerHome = () => {
   useEffect(() => {
     const getTicketsWaitingForMe = async () => {
       const response = await authenticatedFetch(
-        "/api/ticket/RequiringManagerAttention?limit=3"
+        `/api/ticket/RequiringManagerAttention?team=${team}&limit=3`
       );
       if (getIsMounted()) {
         const tickets: Ticket[] = await response.json();
@@ -38,13 +48,17 @@ export const FieldManagerHome = () => {
     getTicketsWaitingForMe();
   }, [getIsMounted]);
 
+  if (!team) {
+    return <Redirect to="/team" />;
+  }
+
   return (
     <>
       <h5>Quick Actions</h5>
       <ul className="list-group quick-actions">
         {projects !== undefined && projects.length > 0 && (
           <li className="list-group-item">
-            <Link to="/project/needsAttention">
+            <Link to={`/${team}/project/needsAttention`}>
               View Projects Requiring Attention{" "}
               <span className="badge badge-pill badge-primary">
                 {projects.length > 3 ? "3+" : projects.length}
@@ -53,10 +67,10 @@ export const FieldManagerHome = () => {
           </li>
         )}
         <li className="list-group-item">
-          <Link to="/project">View All Projects</Link>
+          <Link to={`/${team}/project`}>View All Projects</Link>
         </li>
         <li className="list-group-item">
-          <Link to="/expense/entry">Enter Project Expenses</Link>
+          <Link to={`/${team}/expense/entry`}>Enter Project Expenses</Link>
         </li>
         {projects.slice(0, 3).map((project) => (
           <li key={project.id} className="list-group-item">
@@ -77,7 +91,9 @@ export const FieldManagerHome = () => {
           <h5>Tickets</h5>
           <ul className="list-group quick-actions">
             <li className="list-group-item">
-              <Link to="/ticket/needsAttention">View Open Tickets</Link>
+              <Link to={`/${team}/ticket/needsAttention`}>
+                View Open Tickets
+              </Link>
             </li>
             {tickets.map((ticket) => (
               <li key={ticket.id} className="list-group-item">

--- a/Harvest.Web/ClientApp/src/Home/HomeContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Home/HomeContainer.tsx
@@ -1,61 +1,61 @@
-import React, {useContext} from "react";
+import React, { useContext } from "react";
 
 import AppContext from "../Shared/AppContext";
-import {WorkerHome} from "./WorkerHome";
-import {FieldManagerHome} from "./FieldManagerHome";
-import {SupervisorHome} from "./SupervisorHome";
-import {PIHome} from "./PIHome";
-import {RoleName} from "../types";
-import {useParams} from "react-router";
-import {Redirect} from "react-router-dom";
+import { WorkerHome } from "./WorkerHome";
+import { FieldManagerHome } from "./FieldManagerHome";
+import { SupervisorHome } from "./SupervisorHome";
+import { PIHome } from "./PIHome";
+import { RoleName } from "../types";
+import { useParams } from "react-router";
+import { Redirect } from "react-router-dom";
 
 interface RouteParams {
-    team?: string;
+  team?: string;
 }
 
 const ShowCustomActions = (roles: RoleName[]) => {
-    if (roles.includes("FieldManager")) {
-        return <FieldManagerHome/>;
-    } else if (roles.includes("Supervisor")) {
-        return <SupervisorHome/>;
-    } else if (roles.includes("Worker")) {
-        return <WorkerHome/>;
-    } else {
-        // basic view for PI or person without role
-        return <PIHome/>;
-    }
+  if (roles.includes("FieldManager")) {
+    return <FieldManagerHome />;
+  } else if (roles.includes("Supervisor")) {
+    return <SupervisorHome />;
+  } else if (roles.includes("Worker")) {
+    return <WorkerHome />;
+  } else {
+    // basic view for PI or person without role
+    return <PIHome />;
+  }
 };
 
 export const HomeContainer = () => {
-    const userInfo = useContext(AppContext);
+  const userInfo = useContext(AppContext);
 
-    const {team} = useParams<RouteParams>();
-    
-    // if team is null but we have a non-PI role, go to team picker
-    const nonPIRoles = userInfo.user.roles.filter((role) => role !== "PI");
-    if (!team && nonPIRoles.length > 0) {
-        return <Redirect to="/team"/>;
-    }
+  const { team } = useParams<RouteParams>();
 
-    return (
-        <div className="row mt-3">
-            <div className="col-12 col-md-6">
-                <h1>Welcome to Harvest, {userInfo.user.detail.name}</h1>
-                {userInfo.user.roles.length > 0 && (
-                    <p>You have the following roles: {userInfo.user.roles.join(", ")}.</p>
-                )}
-                <hr/>
-                <div className="quick-actions-wrapper">
-                    {ShowCustomActions(userInfo.user.roles)}
-                </div>
-            </div>
-            <div className="col-12 col-md-6 text-center">
-                <img
-                    className="img-fluid"
-                    src="/media/studentfarmer.svg"
-                    alt="Pencil Sketch of farmer holding produce"
-                ></img>
-            </div>
+  // if team is null but we have a non-PI role, go to team picker
+  const nonPIRoles = userInfo.user.roles.filter((role) => role !== "PI");
+  if (!team && nonPIRoles.length > 0) {
+    return <Redirect to="/team" />;
+  }
+
+  return (
+    <div className="row mt-3">
+      <div className="col-12 col-md-6">
+        <h1>Welcome to Harvest, {userInfo.user.detail.name}</h1>
+        {userInfo.user.roles.length > 0 && (
+          <p>You have the following roles: {userInfo.user.roles.join(", ")}.</p>
+        )}
+        <hr />
+        <div className="quick-actions-wrapper">
+          {ShowCustomActions(userInfo.user.roles)}
         </div>
-    );
+      </div>
+      <div className="col-12 col-md-6 text-center">
+        <img
+          className="img-fluid"
+          src="/media/studentfarmer.svg"
+          alt="Pencil Sketch of farmer holding produce"
+        ></img>
+      </div>
+    </div>
+  );
 };

--- a/Harvest.Web/ClientApp/src/Home/PIHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/PIHome.tsx
@@ -13,7 +13,9 @@ export const PIHome = () => {
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const getProjectsWaitingForMe = async () => {
-      const response = await authenticatedFetch("/api/project/RequiringPIAttention");
+      const response = await authenticatedFetch(
+        "/api/project/RequiringPIAttention"
+      );
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);
@@ -25,7 +27,9 @@ export const PIHome = () => {
 
   useEffect(() => {
     const getTicketsWaitingForMe = async () => {
-      const response = await authenticatedFetch("/api/ticket/RequiringPIAttention?limit=3");
+      const response = await authenticatedFetch(
+        "/api/ticket/RequiringPIAttention?limit=3"
+      );
       if (getIsMounted()) {
         const tickets: Ticket[] = await response.json();
         getIsMounted() && setTickets(tickets);

--- a/Harvest.Web/ClientApp/src/Home/SupervisorHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/SupervisorHome.tsx
@@ -4,16 +4,25 @@ import { Project, Ticket } from "../types";
 import { authenticatedFetch } from "../Util/Api";
 import { StatusToActionRequired } from "../Util/MessageHelpers";
 import { useIsMounted } from "../Shared/UseIsMounted";
+import { useParams } from "react-router";
+
+interface RouteParams {
+  team?: string;
+}
 
 export const SupervisorHome = () => {
   const [projects, setProjects] = useState<Project[]>([]);
   const [tickets, setTickets] = useState<Ticket[]>([]);
 
+  const { team } = useParams<RouteParams>();
+
   const getIsMounted = useIsMounted();
   useEffect(() => {
     // get info on projects requiring approval
     const getProjects = async () => {
-      const response = await authenticatedFetch("/api/project/RequiringManagerAttention");
+      const response = await authenticatedFetch(
+        `/api/project/RequiringManagerAttention?team=${team}`
+      );
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);
@@ -26,7 +35,7 @@ export const SupervisorHome = () => {
   useEffect(() => {
     const getTicketsWaitingForMe = async () => {
       const response = await authenticatedFetch(
-        "/api/ticket/RequiringManagerAttention?limit=3"
+        `/api/ticket/RequiringManagerAttention?team=${team}&limit=3`
       );
       if (getIsMounted()) {
         const tickets: Ticket[] = await response.json();
@@ -42,10 +51,10 @@ export const SupervisorHome = () => {
       <h5>Quick Actions</h5>
       <ul className="list-group quick-actions">
         <li className="list-group-item">
-          <Link to="/project">View Projects</Link>
+          <Link to={`/${team}/project`}>View All Projects</Link>
         </li>
         <li className="list-group-item">
-          <Link to="/expense/entry">Enter Expenses</Link>
+          <Link to={`/${team}/expense/entry`}>Enter Project Expenses</Link>
         </li>
         {projects.slice(0, 3).map((project) => (
           <li key={project.id} className="list-group-item">
@@ -66,7 +75,9 @@ export const SupervisorHome = () => {
           <h5>Tickets</h5>
           <ul className="list-group quick-actions">
             <li className="list-group-item">
-              <Link to="/ticket/needsAttention">View Open Tickets</Link>
+              <Link to={`/${team}/ticket/needsAttention`}>
+                View Open Tickets
+              </Link>
             </li>
             {tickets.map((ticket) => (
               <li key={ticket.id} className="list-group-item">

--- a/Harvest.Web/ClientApp/src/Home/WorkerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/WorkerHome.tsx
@@ -4,14 +4,23 @@ import { Link } from "react-router-dom";
 import { Project } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { authenticatedFetch } from "../Util/Api";
+import { useParams } from "react-router";
+
+interface RouteParams {
+  team?: string;
+}
 
 export const WorkerHome = () => {
   const [projects, setProjects] = useState<Project[]>([]);
 
+  const { team } = useParams<RouteParams>();
+
   const getIsMounted = useIsMounted();
   useEffect(() => {
     const getProjectsWithRecentExpenses = async () => {
-      const response = await authenticatedFetch("/api/expense/GetRecentExpensedProjects");
+      const response = await authenticatedFetch(
+        `/api/expense/GetRecentExpensedProjects?team=${team}`
+      );
       if (getIsMounted()) {
         const projects: Project[] = await response.json();
         getIsMounted() && setProjects(projects);
@@ -26,7 +35,9 @@ export const WorkerHome = () => {
       <h5>Quick Actions</h5>
       <ul className="list-group quick-actions">
         <li className="list-group-item">
-          <Link to="/expense/entry">Enter Expenses for Any Project</Link>
+          <Link to={`/${team}/expense/entry`}>
+            Enter Expenses for Any Project
+          </Link>
         </li>
         {projects.map((project) => (
           <li key={project.id} className="list-group-item">

--- a/Harvest.Web/ClientApp/src/Projects/ProjectListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectListContainer.tsx
@@ -8,6 +8,11 @@ import { authenticatedFetch } from "../Util/Api";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { useParams } from "react-router";
+
+interface RouteParams {
+  team?: string;
+}
 
 interface Props {
   projectSource: string;
@@ -27,11 +32,15 @@ const getListTitle = (projectSource: string) => {
 export const ProjectListContainer = (props: Props) => {
   const [projects, setProjects] = useState<Project[]>([]);
 
+  const { team } = useParams<RouteParams>();
+
   const getIsMounted = useIsMounted();
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await authenticatedFetch(props.projectSource);
+      const response = await authenticatedFetch(
+        `${props.projectSource}?team=${team}`
+      );
 
       if (response.ok) {
         getIsMounted() && setProjects(await response.json());

--- a/Harvest.Web/ClientApp/src/Teams/TeamPicker.tsx
+++ b/Harvest.Web/ClientApp/src/Teams/TeamPicker.tsx
@@ -1,55 +1,58 @@
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 
-import {useHistory, useLocation} from "react-router-dom";
-import {Team} from "../types";
-
+import { useHistory, useLocation } from "react-router-dom";
+import { Team } from "../types";
 
 // Allow selection of a team from a list of teams, then add that team slug to url and redirect
 export const TeamPicker = () => {
-    // get the current page location
-    const location = useLocation();
-    
-    const history = useHistory();
+  // get the current page location
+  const location = useLocation();
 
-    // store teams in state
-    const [teams, setTeams] = useState<Team[]>();
+  const history = useHistory();
 
-    // get the teams from the server
-    useEffect(() => {
-        const getTeams = async () => {
-            const response = await fetch("/api/Team");
-            const data = await response.json();
-            setTeams(data);
-            
-            // if there is only one team, redirect to that team's page immediately
-            if (data.length === 1) {
-                history.replace(`/${data[0].slug}${location.pathname}`);
-            }
-        };
-        getTeams();
-    });
+  // store teams in state
+  const [teams, setTeams] = useState<Team[]>();
 
-    // show loading message while we wait for teams
-    if (!teams) {
-        return <div>Loading teams...</div>;
-    }
+  // get the teams from the server
+  useEffect(() => {
+    const getTeams = async () => {
+      const response = await fetch("/api/Team");
+      const data = await response.json();
 
-    // show the list of teams in big boxes
-    return (
-        <div className="row">
-            {teams.map((team) => (
-                <div className="col-12 col-md-6 col-lg-4 col-xl-3" key={team.id}>
-                    <div className="card">
-                        <div className="card-body">
-                            <h5 className="card-title">{team.name}</h5>
-                            <p className="card-text">{team.name}</p>
-                            <a href={`/${team.slug}${location.pathname}`} className="btn btn-primary">
-                                Use {team.name}
-                            </a>
-                        </div>
-                    </div>
-                </div>
-            ))}
+      // if there is only one team, redirect to that team's page immediately
+      if (data.length === 1) {
+        history.replace(`/${data[0].slug}${location.pathname}`);
+      } else {
+        setTeams(data);
+      }
+    };
+    getTeams();
+  });
+
+  // show loading message while we wait for teams
+  if (!teams) {
+    return <div>Loading teams...</div>;
+  }
+
+  // show the list of teams in big boxes
+  return (
+    <div className="row">
+      {teams.map((team) => (
+        <div className="col-12 col-md-6 col-lg-4 col-xl-3" key={team.id}>
+          <div className="card">
+            <div className="card-body">
+              <h5 className="card-title">{team.name}</h5>
+              <p className="card-text">{team.name}</p>
+              <a
+                href={`/${team.slug}${location.pathname}`}
+                className="btn btn-primary"
+              >
+                Use {team.name}
+              </a>
+            </div>
+          </div>
         </div>
-    );
+      ))}
+    </div>
+  );
 };

--- a/Harvest.Web/ClientApp/src/Tickets/TicketListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketListContainer.tsx
@@ -4,6 +4,11 @@ import { Ticket } from "../types";
 import { TicketTable } from "./TicketTable";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { authenticatedFetch } from "../Util/Api";
+import { useParams } from "react-router";
+
+interface RouteParams {
+  team?: string;
+}
 
 interface Props {
   projectSource: string;
@@ -12,11 +17,15 @@ interface Props {
 export const TicketListContainer = (props: Props) => {
   const [tickets, setTickets] = useState<Ticket[]>([]);
 
+  const { team } = useParams<RouteParams>();
+
   const getIsMounted = useIsMounted();
   useEffect(() => {
     // get rates so we can load up all expense types and info
     const cb = async () => {
-      const response = await authenticatedFetch(props.projectSource);
+      const response = await authenticatedFetch(
+        `${props.projectSource}?team=${team}`
+      );
 
       if (response.ok) {
         getIsMounted() && setTickets(await response.json());

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -98,13 +98,13 @@ namespace Harvest.Web.Controllers.Api
         // Get just the total of unbilled expenses for the current project
         [Authorize(Policy = AccessCodes.WorkerAccess)]
         [HttpGet]
-        public async Task<ActionResult> GetRecentExpensedProjects()
+        public async Task<ActionResult> GetRecentExpensedProjects(string team)
         {
             var user = await _userService.GetCurrentUser();
 
             // get projects where user has entered an expense in the last month
             var projects = await _dbContext.Projects.AsNoTracking()
-                .Where(p => p.IsActive && p.Expenses.Any(e => e.CreatedById == user.Id && e.CreatedOn > DateTime.UtcNow.AddMonths(-1)))
+                .Where(p => p.IsActive && p.Team.Slug == team && p.Expenses.Any(e => e.CreatedById == user.Id && e.CreatedOn > DateTime.UtcNow.AddMonths(-1)))
                 .OrderByDescending(a => a.CreatedOn)
                 .Select(p => new { p.Id, p.Status, p.Name })
                 .Take(4) // limit to 4 projects

--- a/Harvest.Web/Controllers/Api/TicketController.cs
+++ b/Harvest.Web/Controllers/Api/TicketController.cs
@@ -70,11 +70,11 @@ namespace Harvest.Web.Controllers.Api
 
         [HttpGet]
         [Authorize(Policy = AccessCodes.SupervisorAccess)]
-        public async Task<ActionResult> RequiringManagerAttention(int? limit)
+        public async Task<ActionResult> RequiringManagerAttention(string team, int? limit)
         {
             // Get list of top N open tickets in all projects
             var openTickets = _dbContext.Tickets
-                .Where(a => a.Status != Ticket.Statuses.Complete && a.Project.IsActive)
+                .Where(a => a.Status != Ticket.Statuses.Complete && a.Project.IsActive && a.Project.Team.Slug == team)
                 .OrderByDescending(a => a.UpdatedOn);
 
             if (limit.HasValue)

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -242,12 +242,20 @@ namespace Harvest.Web
             
             app.UseEndpoints(endpoints =>
             {
+                // team routes for server-side endpoints
+                endpoints.MapControllerRoute(
+                    name: "default",
+                    pattern: "/{team}/{controller}/{action}/{id?}",
+                    defaults: new { action = "Index" },
+                    constraints: new { controller = "(rate|permissions)" }
+                );
+                
                 // default for MVC server-side endpoints
                 endpoints.MapControllerRoute(
                     name: "default",
                     pattern: "{controller}/{action}/{id?}",
                     defaults: new { controller = "Home", action = "Index" },
-                    constraints: new { controller = "(account|rate|permissions|crop|home|system|help|error|report)" }
+                    constraints: new { controller = "(account|crop|home|system|help|error|report)" }
                 );
 
                 // API routes map to all other controllers


### PR DESCRIPTION
Adds team routes to everything that needs it, like a list of all projects, projects needing attention, ticket lists, expenses, etc.  Rate + Permissions are non-MVC pages which are also now behind /team/xyz paths, though not yet implemented.

Nav is still wonky, it won't work if you are navigating from non-team pages back to team pages -- that'll be fixed later.