### PR TITLE
Almost all client routes now have /team/ in url

### DIFF
--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -48,14 +48,11 @@ function App() {
               path="/(account|crop|home|system|help|report)"
               component={Empty}
             />
-
             {/* Home route */}
             <Route exact path="/" component={HomeContainer} />
-
             {/* Visitors with non-PI roles will require selecting a team */}
             <Route exact path="/team" component={TeamPicker} />
             <Route exact path="/:team/team/" component={HomeContainer} />
-
             {/* Creating a new request requires first picking a team */}
             <Route exact path="/request/create/" component={TeamPicker} />
             <Route
@@ -65,58 +62,56 @@ function App() {
             />
             <ConditionalRoute
               roles={["PI"]}
-              path="/request/approve/:projectId"
+              path="/:team/request/approve/:projectId"
               component={ApprovalContainer}
             />
             <ConditionalRoute
               roles={["PI"]}
-              path="/request/changeAccount/:projectId"
+              path="/:team/request/changeAccount/:projectId"
               component={AccountChangeContainer}
             />
             <Route
-              path="/project/invoices/:projectId"
+              path="/:team/project/invoices/:projectId"
               component={InvoiceListContainer}
             />
             <ConditionalRoute
               roles={["FieldManager", "PI"]}
-              path="/invoice/details/:projectId/:invoiceId"
+              path="/:team/invoice/details/:projectId/:invoiceId"
               component={InvoiceDetailContainer}
             />
             <ConditionalRoute
               roles={["FieldManager", "Supervisor"]}
-              path="/quote/create/:projectId"
+              path="/:team/quote/create/:projectId"
               component={QuoteContainer}
             />
             <ConditionalRoute
               roles={["PI", "FieldManager"]}
-              path="/quote/details/:projectId"
+              path="/:team/quote/details/:projectId"
               component={QuoteDisplayContainer}
             />
             <ConditionalRoute
               roles={["FieldManager"]}
-              path="/project/closeout/:projectId"
+              path="/:team/project/closeout/:projectId"
               component={CloseoutContainer}
             />
             <ConditionalRoute
               roles={["FieldManager"]}
-              path="/project/adhocproject"
+              path="/:team/project/adhocproject"
               component={AdhocProject}
             />
             <ConditionalRoute
               roles={["PI"]}
-              path="/project/closeoutconfirmation/:projectId"
+              path="/:team/project/closeoutconfirmation/:projectId"
               component={CloseoutConfirmationContainer}
             />
-            <ConditionalRoute exact roles={["PI"]} path="/project/mine">
+            <ConditionalRoute exact roles={["PI"]} path="/:team/project/mine">
               <ProjectListContainer projectSource="/api/Project/GetMine" />
             </ConditionalRoute>
-
             <ConditionalRoute
               roles={["FieldManager", "Supervisor", "PI"]}
-              path="/ticket/create/:projectId"
+              path="/:team/ticket/create/:projectId"
               component={TicketCreate}
             />
-
             {/* admin routes requiring team context */}
             <ConditionalRoute
               exact
@@ -146,19 +141,19 @@ function App() {
             >
               <TicketListContainer projectSource="/api/ticket/RequiringManagerAttention" />
             </ConditionalRoute>
-            <ConditionalRoute exact roles={["PI"]} path="/ticket/mine">
+            <ConditionalRoute exact roles={["PI"]} path="/:team/ticket/mine">
               <TicketListContainer projectSource="/api/ticket/RequiringPIAttention" />
             </ConditionalRoute>
             <Route
-              path="/ticket/list/:projectId"
+              path="/:team/ticket/list/:projectId"
               component={TicketsContainer}
             />
             <Route
-              path="/ticket/details/:projectId/:ticketId"
+              path="/:team/ticket/details/:projectId/:ticketId"
               component={TicketDetailContainer}
             />
             <Route
-              path="/project/details/:projectId"
+              path="/:team/project/details/:projectId"
               component={ProjectDetailContainer}
             />
             <ConditionalRoute
@@ -168,17 +163,17 @@ function App() {
             />
             <ConditionalRoute
               roles={["FieldManager", "Supervisor", "Worker"]}
-              path="/expense/entry/:projectId?"
+              path="/:team/expense/entry/:projectId?"
               component={ExpenseEntryContainer}
             />
             <Route
-              path="/expense/unbilled/:projectId"
+              path="/:team/expense/unbilled/:projectId"
               component={UnbilledExpensesContainer}
             />
             <ConditionalRoute
               roles={["FieldManager", "Supervisor"]}
               exact
-              path="/project/map"
+              path="/:team/project/map"
               component={ProjectFields}
             />
             <Route path="*">

--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -104,7 +104,7 @@ function App() {
               path="/:team/project/closeoutconfirmation/:projectId"
               component={CloseoutConfirmationContainer}
             />
-            <ConditionalRoute exact roles={["PI"]} path="/:team/project/mine">
+            <ConditionalRoute exact roles={["PI"]} path="/:team?/project/mine">
               <ProjectListContainer projectSource="/api/Project/GetMine" />
             </ConditionalRoute>
             <ConditionalRoute
@@ -155,11 +155,6 @@ function App() {
             <Route
               path="/:team/project/details/:projectId"
               component={ProjectDetailContainer}
-            />
-            <ConditionalRoute
-              roles={["FieldManager", "Supervisor", "Worker"]}
-              path="/:team/expense/entry/"
-              component={ExpenseEntryContainer}
             />
             <ConditionalRoute
               roles={["FieldManager", "Supervisor", "Worker"]}

--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
         <main role="main" className="main-content-wrapper container">
           <Switch>
             {/* Match any server-side routes and send empty content to let MVC return the view details */}
-            <Route path="/:team/(rate|permissions)" component={Empty} />
+            <Route path="/:team/(rate|permissions|help)" component={Empty} />
             <Route
               path="/(account|crop|home|system|help|report)"
               component={Empty}

--- a/Harvest.Web/ClientApp/src/AppNav.tsx
+++ b/Harvest.Web/ClientApp/src/AppNav.tsx
@@ -15,7 +15,7 @@ import {
 import AppContext from "./Shared/AppContext";
 import { useLocation } from "react-router-dom";
 
-const getTeam = (pathName: string) => {
+const getFirstPath = (pathName: string) => {
   // return the first path token in the pathName
   if (!pathName) {
     return "";
@@ -35,7 +35,12 @@ export const AppNav = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   const location = useLocation();
-  const team = getTeam(location.pathname);
+  const firstPath = getFirstPath(location.pathname).toLowerCase();
+
+  const team = firstPath;
+
+  const nonTeamPage =
+    firstPath === "system" || firstPath === "report" || firstPath === "project";
 
   const toggle = () => setIsOpen(!isOpen);
 
@@ -46,9 +51,9 @@ export const AppNav = () => {
           <NavbarToggler onClick={toggle} />
           <Collapse className="justify-content-between" isOpen={isOpen} navbar>
             <Nav navbar>
-              <ShowFor roles={["FieldManager", "Supervisor"]}>
+              <ShowFor roles={["System"]} condition={nonTeamPage}>
                 <NavItem>
-                  <NavLink href={`/${team}/project`}>All Projects</NavLink>
+                  <NavLink href="/">Home</NavLink>
                 </NavItem>
               </ShowFor>
               <ShowFor roles={["PI"]}>
@@ -56,61 +61,74 @@ export const AppNav = () => {
                   <NavLink href="/project/mine">My Projects</NavLink>
                 </NavItem>
               </ShowFor>
-              <ShowFor roles={["FieldManager", "Supervisor", "Worker"]}>
-                <NavItem>
-                  <NavLink href={`/${team}/expense/entry`}>Expenses</NavLink>
-                </NavItem>
+              <ShowFor condition={!nonTeamPage}>
+                <ShowFor roles={["FieldManager", "Supervisor"]}>
+                  <NavItem>
+                    <NavLink href={`/${team}/project`}>All Projects</NavLink>
+                  </NavItem>
+                </ShowFor>
+                <ShowFor roles={["FieldManager", "Supervisor", "Worker"]}>
+                  <NavItem>
+                    <NavLink href={`/${team}/expense/entry`}>Expenses</NavLink>
+                  </NavItem>
+                </ShowFor>
+                <ShowFor roles={["FieldManager", "Supervisor"]}>
+                  <UncontrolledDropdown nav inNavbar>
+                    <DropdownToggle nav caret>
+                      Team Admin
+                    </DropdownToggle>
+                    <DropdownMenu right>
+                      <ShowFor roles={["FieldManager"]}>
+                        <DropdownItem href={`/${team}/Permissions/Index`}>
+                          Permissions
+                        </DropdownItem>
+                      </ShowFor>
+                      <DropdownItem href={`/${team}/Rate/Index`}>
+                        Rates
+                      </DropdownItem>
+                      <ShowFor roles={["FieldManager"]}>
+                        <DropdownItem href={`/${team}/Crop/Index`}>
+                          Crops
+                        </DropdownItem>
+                      </ShowFor>
+                      <ShowFor roles={["FieldManager"]}>
+                        <DropdownItem divider />
+                        <DropdownItem href={`/${team}/project/adhocproject`}>
+                          Ad-Hoc Project
+                        </DropdownItem>
+                      </ShowFor>
+                      <DropdownItem divider />
+                      <DropdownItem href={`/${team}/Project/Completed`}>
+                        Completed Projects
+                      </DropdownItem>
+                      <DropdownItem href={`/${team}/Project/NeedsAttention`}>
+                        Projects Needing Attention
+                      </DropdownItem>
+                      <DropdownItem href={`/${team}/Ticket/NeedsAttention`}>
+                        Open Tickets
+                      </DropdownItem>
+                    </DropdownMenu>
+                  </UncontrolledDropdown>
+                </ShowFor>
               </ShowFor>
-              <ShowFor roles={["FieldManager", "Supervisor"]}>
+              <ShowFor roles={["System"]}>
                 <UncontrolledDropdown nav inNavbar>
                   <DropdownToggle nav caret>
-                    Admin
+                    System Admin
                   </DropdownToggle>
                   <DropdownMenu right>
-                    <ShowFor roles={["FieldManager"]}>
-                      <DropdownItem href={`/${team}/Permissions/Index`}>
-                        Permissions
-                      </DropdownItem>
-                    </ShowFor>
-                    <DropdownItem href={`/${team}/Rate/Index`}>
-                      Rates
+                    <DropdownItem href={`/System/UpdatePendingExpenses`}>
+                      Unprocessed Expenses
                     </DropdownItem>
-                    <ShowFor roles={["FieldManager"]}>
-                      <DropdownItem href={`/${team}/Crop/Index`}>
-                        Crops
-                      </DropdownItem>
-                    </ShowFor>
-                    <ShowFor roles={["FieldManager"]}>
-                      <DropdownItem divider />
-                      <DropdownItem href={`/${team}/project/adhocproject`}>
-                        Ad-Hoc Project
-                      </DropdownItem>
-                    </ShowFor>
-                    <DropdownItem divider />
-                    <DropdownItem href={`/${team}/Project/Completed`}>
-                      Completed Projects
+                    <DropdownItem href={`/System/Emulate`}>
+                      Emulate
                     </DropdownItem>
-                    <DropdownItem href={`/${team}/Project/NeedsAttention`}>
-                      Projects Needing Attention
+                    <DropdownItem href={`/Report/AllProjects`}>
+                      Reports - Projects
                     </DropdownItem>
-                    <DropdownItem href={`/${team}/Ticket/NeedsAttention`}>
-                      Open Tickets
+                    <DropdownItem href={`/Report/HistoricalRateActivity`}>
+                      Reports - Historical Rate Activity
                     </DropdownItem>
-                    <ShowFor roles={["System"]}>
-                      <DropdownItem divider />
-                      <DropdownItem href={`/System/UpdatePendingExpenses`}>
-                        Unprocessed Expenses
-                      </DropdownItem>
-                      <DropdownItem href={`/System/Emulate`}>
-                        Emulate
-                      </DropdownItem>
-                      <DropdownItem href={`/Report/AllProjects`}>
-                        Reports - Projects
-                      </DropdownItem>
-                      <DropdownItem href={`/Report/HistoricalRateActivity`}>
-                        Reports - Historical Rate Activity
-                      </DropdownItem>
-                    </ShowFor>
                   </DropdownMenu>
                 </UncontrolledDropdown>
               </ShowFor>

--- a/Harvest.Web/ClientApp/src/AppNav.tsx
+++ b/Harvest.Web/ClientApp/src/AppNav.tsx
@@ -13,7 +13,6 @@ import {
   DropdownItem,
 } from "reactstrap";
 import AppContext from "./Shared/AppContext";
-import { useParams } from "react-router";
 import { useLocation } from "react-router-dom";
 
 const getTeam = (pathName: string) => {
@@ -117,7 +116,7 @@ export const AppNav = () => {
               </ShowFor>
 
               <NavItem>
-                <NavLink href={`/Help`}>Help</NavLink>
+                <NavLink href={`/${team}/Help`}>Help</NavLink>
               </NavItem>
             </Nav>
             <div className="d-flex align-items-center user-sign-in">

--- a/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
@@ -8,6 +8,7 @@ import {
   WorkItemImpl,
   ExpenseQueryParams,
   Project,
+  CommonRouteParams,
 } from "../types";
 import { ProjectSelection } from "./ProjectSelection";
 import { ActivityForm } from "../Quotes/ActivityForm";
@@ -31,11 +32,6 @@ import { validatorOptions } from "../constants";
 import { authenticatedFetch } from "../Util/Api";
 import { convertCamelCase } from "../Util/StringFormatting";
 
-interface RouteParams {
-  projectId?: string;
-  team?: string;
-}
-
 const getDefaultActivity = (id: number) => ({
   id,
   name: "Generic Activity",
@@ -52,7 +48,7 @@ const getDefaultActivity = (id: number) => ({
 export const ExpenseEntryContainer = () => {
   const history = useHistory();
 
-  const { projectId, team } = useParams<RouteParams>();
+  const { projectId, team } = useParams<CommonRouteParams>();
   const [rates, setRates] = useState<Rate[]>([]);
   const [inputErrors, setInputErrors] = useState<string[]>([]);
   const context = useOrCreateValidationContext(validatorOptions);
@@ -78,7 +74,7 @@ export const ExpenseEntryContainer = () => {
       if (query.get(ExpenseQueryParams.ReturnOnSubmit) === "true") {
         history.goBack();
       } else {
-        history.push(`/project/details/${projectId}`);
+        history.push(`/${team}/project/details/${projectId}`);
       }
     }
   }, [projectId, history, query, roles]);
@@ -141,7 +137,7 @@ export const ExpenseEntryContainer = () => {
 
   const changeProject = (projectId: number) => {
     // want to go to /expense/entry/[projectId]
-    history.push(`/expense/entry/${projectId}`);
+    history.push(`/${team}/expense/entry/${projectId}`);
   };
 
   const submit = async () => {
@@ -238,7 +234,7 @@ export const ExpenseEntryContainer = () => {
         <div className="card-content">
           <h1>
             Add Expenses for{" "}
-            <Link to={`/project/details/${projectId}`}>
+            <Link to={`/${team}/project/details/${projectId}`}>
               Project {projectId}
             </Link>
           </h1>

--- a/Harvest.Web/ClientApp/src/Expenses/ProjectSelection.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ProjectSelection.tsx
@@ -2,14 +2,10 @@ import React, { useEffect, useState } from "react";
 
 import { FormGroup, Input } from "reactstrap";
 
-import { Project } from "../types";
+import { CommonRouteParams, Project } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { authenticatedFetch } from "../Util/Api";
 import { useParams } from "react-router-dom";
-
-interface RouteParams {
-  team?: string;
-}
 
 interface Props {
   selectedProject: (projectId: number) => void;
@@ -18,7 +14,7 @@ interface Props {
 export const ProjectSelection = (props: Props) => {
   const [projects, setProjects] = useState<Project[]>();
 
-  const { team } = useParams<RouteParams>();
+  const { team } = useParams<CommonRouteParams>();
 
   const getIsMounted = useIsMounted();
   useEffect(() => {

--- a/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
@@ -3,19 +3,15 @@ import { Link, Redirect } from "react-router-dom";
 
 import { authenticatedFetch } from "../Util/Api";
 import { StatusToActionRequired } from "../Util/MessageHelpers";
-import { Project, Ticket } from "../types";
+import { CommonRouteParams, Project, Ticket } from "../types";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { useParams } from "react-router";
-
-interface RouteParams {
-  team?: string;
-}
 
 export const FieldManagerHome = () => {
   const [projects, setProjects] = useState<Project[]>([]);
   const [tickets, setTickets] = useState<Ticket[]>([]);
 
-  const { team } = useParams<RouteParams>();
+  const { team } = useParams<CommonRouteParams>();
 
   const getIsMounted = useIsMounted();
 

--- a/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/FieldManagerHome.tsx
@@ -70,7 +70,7 @@ export const FieldManagerHome = () => {
         </li>
         {projects.slice(0, 3).map((project) => (
           <li key={project.id} className="list-group-item">
-            <Link to={`/project/details/${project.id}`}>
+            <Link to={`/${project.team.slug}/project/details/${project.id}`}>
               Quick jump to {project.name}{" "}
               <span
                 className={`badge badge-primary badge-status-${project.status}`}
@@ -93,7 +93,9 @@ export const FieldManagerHome = () => {
             </li>
             {tickets.map((ticket) => (
               <li key={ticket.id} className="list-group-item">
-                <Link to={`/ticket/details/${ticket.projectId}/${ticket.id}`}>
+                <Link
+                  to={`/${ticket.project.team.slug}/ticket/details/${ticket.projectId}/${ticket.id}`}
+                >
                   View ticket: "{ticket.name}"
                 </Link>
               </li>

--- a/Harvest.Web/ClientApp/src/Home/HomeContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Home/HomeContainer.tsx
@@ -5,13 +5,9 @@ import { WorkerHome } from "./WorkerHome";
 import { FieldManagerHome } from "./FieldManagerHome";
 import { SupervisorHome } from "./SupervisorHome";
 import { PIHome } from "./PIHome";
-import { RoleName } from "../types";
+import { CommonRouteParams, RoleName } from "../types";
 import { useParams } from "react-router";
 import { Redirect } from "react-router-dom";
-
-interface RouteParams {
-  team?: string;
-}
 
 const ShowCustomActions = (roles: RoleName[]) => {
   if (roles.includes("FieldManager")) {
@@ -29,7 +25,7 @@ const ShowCustomActions = (roles: RoleName[]) => {
 export const HomeContainer = () => {
   const userInfo = useContext(AppContext);
 
-  const { team } = useParams<RouteParams>();
+  const { team } = useParams<CommonRouteParams>();
 
   // if team is null but we have a non-PI role, go to team picker
   const nonPIRoles = userInfo.user.roles.filter((role) => role !== "PI");

--- a/Harvest.Web/ClientApp/src/Home/PIHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/PIHome.tsx
@@ -51,7 +51,7 @@ export const PIHome = () => {
         </li>
         {projects.map((project) => (
           <li key={project.id} className="list-group-item">
-            <Link to={`/project/details/${project.id}`}>
+            <Link to={`/${project.team.slug}/project/details/${project.id}`}>
               View project {project.name}{" "}
               <span
                 className={`badge badge-primary badge-status-${project.status}`}
@@ -72,7 +72,9 @@ export const PIHome = () => {
             </li>
             {tickets.map((ticket) => (
               <li key={ticket.id} className="list-group-item">
-                <Link to={`/ticket/details/${ticket.projectId}/${ticket.id}`}>
+                <Link
+                  to={`${ticket.project.team.slug}/ticket/details/${ticket.projectId}/${ticket.id}`}
+                >
                   View ticket: "{ticket.name}"
                 </Link>
               </li>

--- a/Harvest.Web/ClientApp/src/Home/SupervisorHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/SupervisorHome.tsx
@@ -58,7 +58,7 @@ export const SupervisorHome = () => {
         </li>
         {projects.slice(0, 3).map((project) => (
           <li key={project.id} className="list-group-item">
-            <Link to={`/project/details/${project.id}`}>
+            <Link to={`/${project.team.slug}/project/details/${project.id}`}>
               Quick jump to {project.name}{" "}
               <span
                 className={`badge badge-primary badge-status-${project.status}`}
@@ -81,7 +81,9 @@ export const SupervisorHome = () => {
             </li>
             {tickets.map((ticket) => (
               <li key={ticket.id} className="list-group-item">
-                <Link to={`/ticket/details/${ticket.projectId}/${ticket.id}`}>
+                <Link
+                  to={`/${ticket.project.team.slug}/ticket/details/${ticket.projectId}/${ticket.id}`}
+                >
                   View ticket: "{ticket.name}"
                 </Link>
               </li>

--- a/Harvest.Web/ClientApp/src/Projects/ProjectListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectListContainer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { Project } from "../types";
+import { CommonRouteParams, Project } from "../types";
 import { ProjectTable } from "./ProjectTable";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { authenticatedFetch } from "../Util/Api";
@@ -9,10 +9,6 @@ import { authenticatedFetch } from "../Util/Api";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { useParams } from "react-router";
-
-interface RouteParams {
-  team?: string;
-}
 
 interface Props {
   projectSource: string;
@@ -32,7 +28,7 @@ const getListTitle = (projectSource: string) => {
 export const ProjectListContainer = (props: Props) => {
   const [projects, setProjects] = useState<Project[]>([]);
 
-  const { team } = useParams<RouteParams>();
+  const { team } = useParams<CommonRouteParams>();
 
   const getIsMounted = useIsMounted();
   useEffect(() => {
@@ -50,6 +46,8 @@ export const ProjectListContainer = (props: Props) => {
     cb();
   }, [props.projectSource, getIsMounted]);
 
+  const requestUrl = !team ? "/request/create" : `/${team}/request/create`;
+
   return (
     <div className="projectlisttable-wrapper">
       <div className="row justify-content-between mb-3">
@@ -57,7 +55,7 @@ export const ProjectListContainer = (props: Props) => {
           <h1>{getListTitle(props.projectSource)}</h1>
         </div>
         <div className="col text-right">
-          <Link to="/request/create" className="btn btn-sm btn-primary ">
+          <Link to={requestUrl} className="btn btn-sm btn-primary ">
             Create New <FontAwesomeIcon icon={faPlus} />
           </Link>
         </div>

--- a/Harvest.Web/ClientApp/src/Projects/ProjectTable.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectTable.tsx
@@ -29,7 +29,9 @@ export const ProjectTable = (props: Props) => {
         Cell: (data: Cell<Project>) => (
           <div>
             <p>
-              <Link to={`/project/details/${data.row.original.id}`}>
+              <Link
+                to={`/${data.row.original.team.slug}/project/details/${data.row.original.id}`}
+              >
                 #{data.row.original.id} {data.row.original.name}
               </Link>
             </p>

--- a/Harvest.Web/ClientApp/src/Test/mockData.ts
+++ b/Harvest.Web/ClientApp/src/Test/mockData.ts
@@ -5,7 +5,8 @@ import {
   Invoice,
   Project,
   ProjectWithQuote,
-  Rate, Team,
+  Rate,
+  Team,
   Ticket,
 } from "../types";
 
@@ -95,7 +96,7 @@ export const fakeProject: Project = {
     id: 1,
     name: "Team 1",
     slug: "team-1",
-  }
+  },
 };
 
 export const fakeProjectWithQuote: ProjectWithQuote = {
@@ -139,7 +140,7 @@ export const fakeProjectWithQuote: ProjectWithQuote = {
       id: 1,
       name: "Team 1",
       slug: "team-1",
-    }
+    },
   },
   quote: null,
 };
@@ -188,6 +189,7 @@ export const fakeTickets: Ticket[] = [
     attachments: [],
     status: "Requested",
     createdOn: new Date("2021-01-15T00:00:00"),
+    project: fakeProject,
   },
   {
     id: 2,
@@ -199,6 +201,7 @@ export const fakeTickets: Ticket[] = [
     attachments: [],
     status: "Requested",
     createdOn: new Date("2021-01-15T00:00:00"),
+    project: fakeProject,
   },
   {
     id: 3,
@@ -210,6 +213,7 @@ export const fakeTickets: Ticket[] = [
     attachments: [],
     status: "Requested",
     createdOn: new Date("2021-01-15T00:00:00"),
+    project: fakeProject,
   },
   {
     id: 4,
@@ -221,6 +225,7 @@ export const fakeTickets: Ticket[] = [
     attachments: [],
     status: "Requested",
     createdOn: new Date("2021-01-15T00:00:00"),
+    project: fakeProject,
   },
 ];
 

--- a/Harvest.Web/ClientApp/src/Tickets/TicketTable.tsx
+++ b/Harvest.Web/ClientApp/src/Tickets/TicketTable.tsx
@@ -18,7 +18,7 @@ export const TicketTable = (props: Props) => {
         Cell: (data: Cell<Ticket>) => (
           <div>
             <Link
-              to={`/ticket/details/${data.row.original.projectId}/${data.row.original.id}`}
+              to={`/${data.row.original.project.team.slug}/ticket/details/${data.row.original.projectId}/${data.row.original.id}`}
             >
               #{data.row.original.id}
             </Link>

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -78,9 +78,9 @@ export interface Invoice {
 }
 
 export interface Team {
-    id: number;
-    name: string;
-    slug: string;
+  id: number;
+  name: string;
+  slug: string;
 }
 
 export interface User {
@@ -378,4 +378,10 @@ export interface Result<T> {
   value: T;
   isError: boolean;
   message: string;
+}
+
+export interface CommonRouteParams {
+  team?: string;
+  projectId?: string;
+  ticketId?: string;
 }

--- a/Harvest.Web/ClientApp/src/types.ts
+++ b/Harvest.Web/ClientApp/src/types.ts
@@ -297,6 +297,8 @@ export interface ProjectAccount {
 export interface Ticket {
   id: number;
   projectId: number;
+
+  project: Project;
   name: string;
   requirements: string;
   dueDate?: Date;

--- a/Harvest.Web/Controllers/Api/ProjectController.cs
+++ b/Harvest.Web/Controllers/Api/ProjectController.cs
@@ -123,6 +123,7 @@ namespace Harvest.Web.Controllers.Api
             // TODO: only show projects where between start and end?
             return Ok(await _dbContext.Projects
                 .Include(p => p.PrincipalInvestigator)
+                .Include(p => p.Team)
                 .Where(p => p.IsActive && p.PrincipalInvestigatorId == user.Id)
                 .ToArrayAsync());
         }

--- a/Harvest.Web/Controllers/Api/TicketController.cs
+++ b/Harvest.Web/Controllers/Api/TicketController.cs
@@ -40,7 +40,7 @@ namespace Harvest.Web.Controllers.Api
         [Authorize(policy: AccessCodes.PrincipalInvestigator)]
         public async Task<ActionResult> GetList(int projectId, int? maxRows)
         {
-            var ticketsQuery = _dbContext.Tickets.Where(a => a.ProjectId == projectId).OrderByDescending(a => a.UpdatedOn);
+            var ticketsQuery = _dbContext.Tickets.Include(a => a.Project.Team).Where(a => a.ProjectId == projectId).OrderByDescending(a => a.UpdatedOn);
             if (maxRows.HasValue)
             {
                 //I actually don't like this take 5, too easy to loose that there maybe uncompleted tickets not showing here. but worry about it later.
@@ -57,6 +57,7 @@ namespace Harvest.Web.Controllers.Api
 
             // Get list of top N open tickets in PI projects
             var openTickets = _dbContext.Tickets
+                .Include(a => a.Project.Team)
                 .Where(a => a.Status != Ticket.Statuses.Complete && a.Project.IsActive && a.Project.PrincipalInvestigatorId == user.Id)
                 .OrderByDescending(a => a.UpdatedOn);
 
@@ -74,6 +75,7 @@ namespace Harvest.Web.Controllers.Api
         {
             // Get list of top N open tickets in all projects
             var openTickets = _dbContext.Tickets
+                .Include(a => a.Project.Team)
                 .Where(a => a.Status != Ticket.Statuses.Complete && a.Project.IsActive && a.Project.Team.Slug == team)
                 .OrderByDescending(a => a.UpdatedOn);
 

--- a/Harvest.Web/Startup.cs
+++ b/Harvest.Web/Startup.cs
@@ -247,7 +247,7 @@ namespace Harvest.Web
                     name: "default",
                     pattern: "/{team}/{controller}/{action}/{id?}",
                     defaults: new { action = "Index" },
-                    constraints: new { controller = "(rate|permissions)" }
+                    constraints: new { controller = "(help|rate|permissions)" }
                 );
                 
                 // default for MVC server-side endpoints


### PR DESCRIPTION
All links from homepage, plus project, ticket and expense lists have been changed to include team.  Nav redone to show team if available, or otherwise hide certain links.

Nav inside pages still need to be updated.

Server routes not changed, though some could potentially be modified to sit behind `/api/team/abc`.  