### PR TITLE
Rh/firefox decimals

### DIFF
--- a/Harvest.Core/Data/DbInitializer.cs
+++ b/Harvest.Core/Data/DbInitializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -84,6 +84,17 @@ namespace Harvest.Core.Data
                 Iam = "1000007413"
             };
             await CheckOrCreatePermission(systemRole, user);
+
+            user = new User
+            {
+                Email = "laholstege@ucdavis.edu",
+                Kerberos = "holstege",
+                FirstName = "River",
+                LastName = "Holstege",
+                Iam = "1000243041"
+            };
+            await CheckOrCreatePermission(systemRole, user);
+
 
             await UpdateTeamPermissions();
 

--- a/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
@@ -19,6 +19,7 @@ import { workItemSchema } from "../schemas";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import StatefulInput from "../Shared/StatefulInput";
 
 interface WorkItemsFormProps {
   adjustment: number;
@@ -203,7 +204,7 @@ const WorkItemForm = (props: WorkItemFormProps) => {
       <div className="col-4 col-md-3">
         <InputGroup>
           <InputGroupText>{workItem.unit || ""}</InputGroupText>
-          <Input
+          <StatefulInput
             className={getClassName("quantity")}
             type="number"
             id="units"

--- a/Harvest.Web/ClientApp/src/Shared/StatefulInput.tsx
+++ b/Harvest.Web/ClientApp/src/Shared/StatefulInput.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { useState } from "react";
+import { Input, InputProps } from "reactstrap";
+
+interface IProps extends InputProps {
+  value: string | number;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const StatefulInput = (props: IProps) => {
+  const [internalValue, setInternalValue] = useState(
+    props.value.toString() ?? ""
+  );
+  return (
+    <Input
+      {...props}
+      value={internalValue}
+      onChange={(e) => {
+        setInternalValue(e.target.value);
+        props.onChange(e);
+      }}
+    />
+  );
+};
+
+export default StatefulInput;


### PR DESCRIPTION
closes #884 

the issue was that the state of the input could not be changed to something that did not pass parseFloat(). now the state of the input can be erroneous and our onChange() and errors still work the same, the user is just actually allowed to type whatever they want and our parent state will only change to something that passes parseFloat(). 

in firefox this change lets the user type non-numbers into the input, though they don't pass validation. chrome is nice and limits it to numbers. i do not have edge installed lol 

not sure if there's anywhere else that needs a stateful input? @jSylvestre 