### PR TITLE
update internal state if parent changes itself

### DIFF
--- a/Harvest.Web/ClientApp/src/Shared/StatefulInput.tsx
+++ b/Harvest.Web/ClientApp/src/Shared/StatefulInput.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Input, InputProps } from "reactstrap";
 
 interface IProps extends InputProps {
@@ -11,6 +11,17 @@ const StatefulInput = (props: IProps) => {
   const [internalValue, setInternalValue] = useState(
     props.value.toString() ?? ""
   );
+
+  useEffect(() => {
+    // if parent changes value, update our internal value
+    // this could happen on a slow load, or if the parent zero's out the value
+    // this is not best practices for how to handle state (should have one source of truth)
+    // but it's the easiest way to have a string input for our number field (for floats) and not change the type
+    if (props.value.toString() !== internalValue) {
+      setInternalValue(props.value.toString());
+    }
+  }, [props.value, internalValue]);
+
   return (
     <Input
       {...props}

--- a/Harvest.Web/ClientApp/src/Shared/StatefulInput.tsx
+++ b/Harvest.Web/ClientApp/src/Shared/StatefulInput.tsx
@@ -18,7 +18,7 @@ const StatefulInput = (props: IProps) => {
     // this is not best practices for how to handle state (should have one source of truth)
     // but it's the easiest way to have a string input for our number field (for floats) and not change the type
     if (props.value.toString() !== internalValue) {
-      setInternalValue(props.value.toString());
+      setInternalValue(!!props.value ? props.value.toString() : "");
     }
   }, [props.value, internalValue]);
 

--- a/Harvest.Web/ClientApp/src/Shared/StatefulInput.tsx
+++ b/Harvest.Web/ClientApp/src/Shared/StatefulInput.tsx
@@ -17,10 +17,8 @@ const StatefulInput = (props: IProps) => {
     // this could happen on a slow load, or if the parent zero's out the value
     // this is not best practices for how to handle state (should have one source of truth)
     // but it's the easiest way to have a string input for our number field (for floats) and not change the type
-    if (props.value.toString() !== internalValue) {
-      setInternalValue(!!props.value ? props.value.toString() : "");
-    }
-  }, [props.value, internalValue]);
+    setInternalValue(!!props.value ? props.value.toString() : "");
+  }, [props.value]);
 
   return (
     <Input


### PR DESCRIPTION
so, in some ways this is the easiest/cleanest way to get the job done (though it will call this effect every time the state or prop changes), but it's not what we're supposed to do–we're supposed to move the state up and have it be managed by a parent. the easiest way to do that would be to type quantity as a string and modify the object itself, or make a state at the parent level and manage it there. thoughts? 