### PR TITLE
Refactors expense entry with edit mode

### DIFF
--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -204,8 +204,9 @@ function App() {
             <ConditionalRoute
               roles={["FieldManager", "Supervisor", "Worker"]}
               path="/:team/expense/entry/:projectId?"
-              component={ExpenseEntryContainer}
-            />
+            >
+              <ExpenseEntryContainer isEditMode={false} />
+            </ConditionalRoute>
             <ConditionalRoute
               roles={["Worker"]}
               exact
@@ -215,8 +216,9 @@ function App() {
             <ConditionalRoute
               roles={["FieldManager", "Supervisor"]}
               path="/:team/expense/edit/:projectId/:expenseId"
-              component={ExpenseEntryContainer}
-            />
+            >
+              <ExpenseEntryContainer isEditMode={true} />
+            </ConditionalRoute>
             <Route
               path="/:team/expense/unbilled/:projectId/:shareId?"
               component={UnbilledExpensesContainer}

--- a/Harvest.Web/ClientApp/src/AppNav.tsx
+++ b/Harvest.Web/ClientApp/src/AppNav.tsx
@@ -67,7 +67,7 @@ export const AppNav = () => {
                     <NavLink href={`/${team}/project`}>All Projects</NavLink>
                   </NavItem>
                 </ShowFor>
-                <ShowFor roles={["FieldManager", "Supervisor", "Worker"]}>
+                <ShowFor roles={["Worker"]}>
                   <NavItem>
                     <NavLink href={`/${team}/mobile/token`}>App Link</NavLink>
                   </NavItem>

--- a/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.test.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render, unmountComponentAtNode } from "react-dom";
 import { MemoryRouter, Route } from "react-router-dom";
 import { act, Simulate } from "react-dom/test-utils";
-import { Input } from "reactstrap";
 
 import { ExpenseEntryContainer } from "./ExpenseEntryContainer";
 import { fakeAppContext, sampleRates, fakeProject } from "../Test/mockData";
@@ -71,7 +70,7 @@ describe("Expense Entry Container", () => {
       render(
         <MemoryRouter initialEntries={["/team1/expense/entry/3"]}>
           <Route path="/:team/expense/entry/:projectId">
-            <ExpenseEntryContainer />
+            <ExpenseEntryContainer isEditMode={false} />
           </Route>
         </MemoryRouter>,
         container
@@ -89,7 +88,7 @@ describe("Expense Entry Container", () => {
       render(
         <MemoryRouter initialEntries={["/team1/expense/entry/3"]}>
           <Route path="/:team/expense/entry/:projectId">
-            <ExpenseEntryContainer />
+            <ExpenseEntryContainer isEditMode={false} />
           </Route>
         </MemoryRouter>,
         container
@@ -114,7 +113,7 @@ describe("Expense Entry Container", () => {
       render(
         <MemoryRouter initialEntries={["/team1/expense/entry/3"]}>
           <Route path="/:team/expense/entry/:projectId">
-            <ExpenseEntryContainer />
+            <ExpenseEntryContainer isEditMode={false} />
           </Route>
         </MemoryRouter>,
         container
@@ -144,7 +143,7 @@ describe("Expense Entry Container", () => {
       render(
         <MemoryRouter initialEntries={["/team1/expense/edit/3/1"]}>
           <Route path="/:team/expense/edit/:projectId/:expenseId">
-            <ExpenseEntryContainer />
+            <ExpenseEntryContainer isEditMode={true} />
           </Route>
         </MemoryRouter>,
         container

--- a/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
@@ -78,13 +78,11 @@ export const ExpenseEntryContainer = (props: Props) => {
 
     const loadExpense = async () => {
       try {
-        console.log("Loading expense data for expenseId:", expenseId);
         const response = await authenticatedFetch(
           `/api/${team}/Expense/Get/${expenseId}`
         );
         if (response.ok) {
           const expense: Expense = await response.json();
-          console.log("Loaded expense:", expense);
           getIsMounted() && setExistingExpense(expense);
 
           // Create work item from existing expense
@@ -115,7 +113,6 @@ export const ExpenseEntryContainer = (props: Props) => {
             workItems: allWorkItems,
           };
 
-          console.log("Created activity with workItems:", activity);
           getIsMounted() && setActivities([activity]);
         } else {
           console.error(

--- a/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/ExpenseEntryContainer.tsx
@@ -45,7 +45,11 @@ const getDefaultActivity = (id: number) => ({
   ],
 });
 
-export const ExpenseEntryContainer = () => {
+interface Props {
+  isEditMode: boolean;
+}
+
+export const ExpenseEntryContainer = (props: Props) => {
   const history = useHistory();
 
   const { projectId, team, expenseId } = useParams<CommonRouteParams>();
@@ -54,7 +58,7 @@ export const ExpenseEntryContainer = () => {
   const context = useOrCreateValidationContext(validatorOptions);
   const [project, setProject] = useState<Project>();
   const [existingExpense, setExistingExpense] = useState<Expense | null>(null);
-  const isEditMode = Boolean(expenseId);
+  const isEditMode = props.isEditMode;
 
   // activities are groups of expenses
   const [activities, setActivities] = useState<Activity[]>([]);

--- a/Harvest.Web/ClientApp/src/Expenses/PendingExpensesListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Expenses/PendingExpensesListContainer.tsx
@@ -85,11 +85,15 @@ export const PendingExpensesListContainer = (props: Props) => {
   const approveExpense = async (expense: Expense) => {
     // Determine which API endpoint to use based on showAll
     const endpoint = showAll
-      ? `/api/${team}/Expense/ApproveExpense`
-      : `/api/${team}/Expense/ApproveMyWorkerExpense`;
+      ? `/api/${team}/Expense/ApproveExpenses`
+      : `/api/${team}/Expense/ApproveMyWorkerExpenses`;
 
-    const request = authenticatedFetch(`${endpoint}?expenseId=${expense.id}`, {
+    const request = authenticatedFetch(endpoint, {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([expense.id]),
     });
 
     setNotification(request, "Approving Expense", async (response) => {

--- a/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Fields/FieldContainer.tsx
@@ -41,8 +41,6 @@ export class FieldContainer extends React.Component<Props, State> {
 
   _addDefaultField = (e: any) => {
     const { layer } = e;
-    console.log(e);
-    console.log("creating field", this.props.fields);
 
     const newId = Math.max(...this.props.fields.map((f) => f.id), 0) + 1;
     const newField: Field = {
@@ -152,7 +150,6 @@ export class FieldContainer extends React.Component<Props, State> {
 
   // This is used to trigger the modal to open
   _updateFieldId = (field?: Field) => {
-    console.log(this.state.editFieldId);
     if (field) {
       this.setState({ editFieldId: field.id });
     } else {

--- a/Harvest.Web/ClientApp/src/Invoices/InvoiceListContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Invoices/InvoiceListContainer.tsx
@@ -27,7 +27,6 @@ export const InvoiceListContainer = () => {
       !userInfo.user.roles.includes("PI")
     ) {
       userInfo.user.roles.push("Shared");
-      console.log("User Roles: ", userInfo.user.roles);
     }
     // get rates so we can load up all expense types and info
     const cb = async () => {

--- a/Harvest.Web/ClientApp/src/Mobile/MobileTokenContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Mobile/MobileTokenContainer.tsx
@@ -19,7 +19,6 @@ export const MobileTokenContainer = () => {
     setError("");
 
     try {
-      console.log("Generating mobile token for team:", team);
       const response = await authenticatedFetch(`/api/${team}/Link`);
 
       if (response.ok) {

--- a/Harvest.Web/ClientApp/src/ProjectPermissions/AddProjectPermission.tsx
+++ b/Harvest.Web/ClientApp/src/ProjectPermissions/AddProjectPermission.tsx
@@ -95,7 +95,6 @@ export const AddProjectPermission = () => {
 
     if (response.ok) {
       const data = await response.json();
-      console.log("Project Permission Added: ", data);
       history.push(`/${team}/Project/Details/${project.id}`);
     }
   };

--- a/Harvest.Web/ClientApp/src/Projects/ProjectFields.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectFields.tsx
@@ -30,7 +30,6 @@ export const ProjectFields = () => {
 
       if (response.ok) {
         const result = await response.json();
-        console.log(result);
         getIsMounted() && setFields(result);
       }
     };

--- a/Harvest.Web/ClientApp/src/Shared/ReactTable.tsx
+++ b/Harvest.Web/ClientApp/src/Shared/ReactTable.tsx
@@ -200,28 +200,6 @@ export const ReactTable = ({
                         }
                       : undefined
                   }
-                  style={
-                    onRowClick
-                      ? {
-                          cursor: "pointer",
-                          transition: "background-color 0.2s",
-                        }
-                      : undefined
-                  }
-                  onMouseEnter={
-                    onRowClick
-                      ? (e) => {
-                          e.currentTarget.style.backgroundColor = "#f8f9fa";
-                        }
-                      : undefined
-                  }
-                  onMouseLeave={
-                    onRowClick
-                      ? (e) => {
-                          e.currentTarget.style.backgroundColor = "";
-                        }
-                      : undefined
-                  }
                 >
                   {row.cells.map((cell) => {
                     return (

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -314,30 +314,6 @@ namespace Harvest.Web.Controllers.Api
 
         }
 
-        [HttpPost]
-        [Authorize(Policy = AccessCodes.SupervisorAccess)]
-        public async Task<ActionResult> ApproveMyWorkerExpense(int expenseId)
-        {
-            var user = await _userService.GetCurrentUser();
-            var myWorkers = await _dbContext.Permissions.Where(a => a.UserId == user.Id && a.Team.Slug == TeamSlug).Include(a => a.Children).ThenInclude(a => a.User)
-                .SelectMany(a => a.Children).Select(a => a.User).Select(a => a.Id).ToListAsync();
-
-            var expense = await _dbContext.Expenses.SingleOrDefaultAsync(a => a.Id == expenseId && a.Project.Team.Slug == TeamSlug && myWorkers.Contains(a.CreatedById.Value));
-            if (expense == null)
-            {
-                return NotFound();
-            }
-            if (expense.Approved)
-            {
-                return BadRequest("Expense is already approved");
-            }
-            expense.ApprovedBy = user;
-            expense.ApprovedOn = DateTime.UtcNow;
-            expense.Approved = true;
-            //await _historyService.ExpenseApproved(expense.ProjectId, expense); //TODO: Add this
-            await _dbContext.SaveChangesAsync();
-            return Ok(expense);
-        }
 
         [HttpPost]
         [Authorize(Policy = AccessCodes.SupervisorAccess)]
@@ -364,28 +340,6 @@ namespace Harvest.Web.Controllers.Api
 
             await _dbContext.SaveChangesAsync();
             return Ok(expenses);
-        }
-
-        [HttpPost]
-        [Authorize(Policy = AccessCodes.FieldManagerAccess)]
-        public async Task<ActionResult> ApproveExpense(int expenseId)
-        {
-            var expense = await _dbContext.Expenses.SingleOrDefaultAsync(a => a.Id == expenseId && a.Project.Team.Slug == TeamSlug);
-            if (expense == null)
-            {
-                return NotFound();
-            }
-            if (expense.Approved)
-            {
-                return BadRequest("Expense is already approved");
-            }
-            var user = await _userService.GetCurrentUser();
-            expense.ApprovedBy = user;
-            expense.ApprovedOn = DateTime.UtcNow;
-            expense.Approved = true;
-            //await _historyService.ExpenseApproved(expense.ProjectId, expense); //TODO: Add this
-            await _dbContext.SaveChangesAsync();
-            return Ok(expense);
         }
 
         [HttpPost]

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -95,11 +95,8 @@ namespace Harvest.Web.Controllers.Api
                 // Check if the worker belongs to the supervisor
                 var myWorkers = await _dbContext.Permissions
                     .Where(a => a.UserId == user.Id && a.Team.Slug == TeamSlug)
-                    .Include(a => a.Children)
-                    .ThenInclude(a => a.User)
                     .SelectMany(a => a.Children)
-                    .Select(a => a.User)
-                    .Select(a => a.Id)
+                    .Select(c => c.UserId)
                     .ToListAsync();
 
                 if (expense.CreatedById == null || !myWorkers.Contains(expense.CreatedById.Value))

--- a/Test/TestsControllers/TestsApiControllers/ExpenseControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/ExpenseControllerTests.cs
@@ -44,7 +44,7 @@ namespace Test.TestsControllers.TestsApiControllers
         [Fact]
         public void TestControllerContainsExpectedNumberOfPublicMethods()
         {
-            ControllerReflection.ControllerPublicMethods(13);
+            ControllerReflection.ControllerPublicMethods(11);
         }
 
         [Fact]
@@ -108,42 +108,32 @@ namespace Test.TestsControllers.TestsApiControllers
             authAttribute.ElementAt(0).Policy.ShouldBe(AccessCodes.FieldManagerAccess);
             ControllerReflection.MethodExpectedAttribute<AsyncStateMachineAttribute>("GetAllPendingExpenses", countAdjustment + 3);
 
-            //8
-            ControllerReflection.MethodExpectedAttribute<HttpPostAttribute>("ApproveMyWorkerExpense", countAdjustment + 3);
-            authAttribute = ControllerReflection.MethodExpectedAttribute<AuthorizeAttribute>("ApproveMyWorkerExpense", countAdjustment + 3);
-            authAttribute.ShouldNotBeNull();
-            authAttribute.ElementAt(0).Policy.ShouldBe(AccessCodes.SupervisorAccess);
-            ControllerReflection.MethodExpectedAttribute<AsyncStateMachineAttribute>("ApproveMyWorkerExpense", countAdjustment + 3);
+           
 
-            //9
+            //8
             ControllerReflection.MethodExpectedAttribute<HttpPostAttribute>("ApproveMyWorkerExpenses", countAdjustment + 3);
             authAttribute = ControllerReflection.MethodExpectedAttribute<AuthorizeAttribute>("ApproveMyWorkerExpenses", countAdjustment + 3);
             authAttribute.ShouldNotBeNull();
             authAttribute.ElementAt(0).Policy.ShouldBe(AccessCodes.SupervisorAccess);
             ControllerReflection.MethodExpectedAttribute<AsyncStateMachineAttribute>("ApproveMyWorkerExpenses", countAdjustment + 3);
 
-            //10
-            ControllerReflection.MethodExpectedAttribute<HttpPostAttribute>("ApproveExpense", countAdjustment + 3);
-            authAttribute = ControllerReflection.MethodExpectedAttribute<AuthorizeAttribute>("ApproveExpense", countAdjustment + 3);
-            authAttribute.ShouldNotBeNull();
-            authAttribute.ElementAt(0).Policy.ShouldBe(AccessCodes.FieldManagerAccess);
-            ControllerReflection.MethodExpectedAttribute<AsyncStateMachineAttribute>("ApproveExpense", countAdjustment + 3);
+          
 
-            //11
+            //9
             ControllerReflection.MethodExpectedAttribute<HttpPostAttribute>("ApproveExpenses", countAdjustment + 3);
             authAttribute = ControllerReflection.MethodExpectedAttribute<AuthorizeAttribute>("ApproveExpenses", countAdjustment + 3);
             authAttribute.ShouldNotBeNull();
             authAttribute.ElementAt(0).Policy.ShouldBe(AccessCodes.FieldManagerAccess);
             ControllerReflection.MethodExpectedAttribute<AsyncStateMachineAttribute>("ApproveExpenses", countAdjustment + 3);
 
-            //12
+            //10
             ControllerReflection.MethodExpectedAttribute<HttpPostAttribute>("Edit", countAdjustment + 3);
             authAttribute = ControllerReflection.MethodExpectedAttribute<AuthorizeAttribute>("Edit", countAdjustment + 3);
             authAttribute.ShouldNotBeNull();
             authAttribute.ElementAt(0).Policy.ShouldBe(AccessCodes.SupervisorAccess);
             ControllerReflection.MethodExpectedAttribute<AsyncStateMachineAttribute>("Edit", countAdjustment + 3);
 
-            //13
+            //11
             ControllerReflection.MethodExpectedAttribute<HttpGetAttribute>("Get", countAdjustment + 4, showListOfAttributes: true);
             authAttribute = ControllerReflection.MethodExpectedAttribute<AuthorizeAttribute>("Get", countAdjustment + 4);
             authAttribute.ShouldNotBeNull();


### PR DESCRIPTION
Moves the ExpenseEntryContainer component into a conditional route and passes a prop to determine if the component should be in "edit" mode or "new" mode. Hides the mobile app link from Field Managers and Supervisors since it is only applicable to Workers.