### PR TITLE
Changes API endpoint to use POST

### DIFF
--- a/Harvest.Web/Controllers/Api/LinkController.cs
+++ b/Harvest.Web/Controllers/Api/LinkController.cs
@@ -48,7 +48,7 @@ namespace Harvest.Web.Controllers.Api
             return Ok(permission.Token);
         }
 
-        [HttpGet]
+        [HttpPost]
         [AllowAnonymous]
         [Route("api/getapi/{id}")]
         public async Task<IActionResult> GetApi(Guid id)


### PR DESCRIPTION
Updates the HTTP method for the "getapi" endpoint from GET to POST. This is likely done to align with API design best practices or to accommodate request bodies in future updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The endpoint at /api/getapi/{id} now requires HTTP POST instead of GET. Clients must update requests to use POST. Response format and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->