### PR TITLE
Adds link to mobile app token generation

### DIFF
--- a/Harvest.Web/ClientApp/src/Home/WorkerHome.tsx
+++ b/Harvest.Web/ClientApp/src/Home/WorkerHome.tsx
@@ -34,6 +34,9 @@ export const WorkerHome = () => {
             Enter Expenses for Any Project
           </Link>
         </li>
+        <li className="list-group-item">
+          <Link to={`/${team}/mobile/token`}>Link Mobile App</Link>
+        </li>
         {projects.map((project) => (
           <li key={project.id} className="list-group-item">
             <Link to={`/${team}/expense/entry/${project.id}`}>

--- a/Harvest.Web/Controllers/Api/LinkController.cs
+++ b/Harvest.Web/Controllers/Api/LinkController.cs
@@ -50,6 +50,7 @@ namespace Harvest.Web.Controllers.Api
 
         [HttpPost]
         [AllowAnonymous]
+        [IgnoreAntiforgeryToken]
         [Route("api/getapi/{id}")]
         public async Task<IActionResult> GetApi(Guid id)
         {
@@ -58,7 +59,7 @@ namespace Harvest.Web.Controllers.Api
                 .Where(p => p.Token == id && p.TokenExpires > DateTime.UtcNow)
                 .SingleOrDefaultAsync();
             if (permission == null)
-                {
+            {
                 return NotFound();
             }
             var apiKey = await _apiKeyService.GenerateApiKeyAsync(permission.Id);


### PR DESCRIPTION
Adds a link to the worker home page that allows users to generate a token for linking the mobile app to their account. Also adds attribute to ignore antiforgery token for the getapi endpoint since this is used by the mobile app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Link Mobile App” quick action on the Worker home page to streamline mobile app setup.
* **Bug Fixes**
  * Improved request handling for the mobile app linking endpoint to ensure smoother link generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->