### PR TITLE
Enables mobile app link without team param

### DIFF
--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -213,6 +213,11 @@ function App() {
               path="/:team/mobile/token"
               component={MobileTokenContainer}
             />
+            <Route
+              exact
+              path="/mobile/token"
+              component={MobileTokenContainer}
+            />
             <ConditionalRoute
               roles={["FieldManager", "Supervisor"]}
               path="/:team/expense/edit/:projectId/:expenseId"

--- a/Harvest.Web/Controllers/Api/LinkController.cs
+++ b/Harvest.Web/Controllers/Api/LinkController.cs
@@ -69,6 +69,31 @@ namespace Harvest.Web.Controllers.Api
             return Ok(new { apiKey, team = permission.Team.Slug });
         }
 
+        [HttpGet]
+        [Route("/api/Link/GetTeam")]
+        public async Task<IActionResult> GetTeam()
+        {
+            var user = await _userService.GetCurrentUser();
+            var permissions = await _dbContext.Permissions
+                .Include(p => p.Team)
+                .Where(p => p.UserId == user.Id && p.Role.Name == Role.Codes.Worker)
+                .ToListAsync();
+
+            if (permissions.Count == 0)
+            {
+                return NotFound("No worker permissions found");
+            }
+
+            if (permissions.Count == 1)
+            {
+                return Ok(permissions.Single().Team.Slug);
+            }
+
+            // Multiple permissions found - ambiguous team selection
+            return BadRequest("Multiple worker permissions found - cannot determine single team");
+
+        }
+
         //Can use this for testing
         //[HttpGet]
         //[AllowAnonymous]


### PR DESCRIPTION
Allows users to access the mobile app link without a team parameter in the URL.

If the team is not provided in the route, the application will attempt to fetch the team from the API. If the user only belongs to one team, it's automatically selected. If the user belongs to multiple teams or no team, the user will be redirected to the team selection page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now access the mobile token page directly at /mobile/token without selecting a team first.
  - If you belong to exactly one team, the app auto-detects it and proceeds.
  - A brief loading state appears while your team is determined.
  - If no team can be identified, you’ll be redirected to the team selection page.
  - Token generation now works based on the detected team, enabling a smoother setup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->