### PR TITLE
Shows pending quote link for FieldManagers

### DIFF
--- a/Harvest.Web/ClientApp/src/Projects/ProjectDetailContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Projects/ProjectDetailContainer.tsx
@@ -333,6 +333,24 @@ export const ProjectDetailContainer = () => {
         </Link>
       ),
     }),
+    useFor({
+      roles: ["FieldManager"],
+      condition:
+        // all statuses with approved quotes
+        project.status === "PendingApproval",
+      children: (
+        <Link
+          className="btn btn-primary btn-sm mr-4"
+          to={
+            shareId
+              ? `/${team}/quote/details/${project.id}/${shareId}`
+              : `/${team}/quote/details/${project.id}`
+          }
+        >
+          View Pending Quote <FontAwesomeIcon icon={faEye} />
+        </Link>
+      ),
+    }),
     useForPiOnly({
       project: project,
       // all statuses


### PR DESCRIPTION
Displays a "View Pending Quote" link to FieldManagers when the project status is "PendingApproval". This allows FieldManagers to quickly access the quote details for projects awaiting approval.


<img width="2650" height="1176" alt="image" src="https://github.com/user-attachments/assets/a5edcd01-6aac-4b48-8f32-5aaafc41a961" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “View Pending Quote” action on project details when a project is Pending Approval.
  * Action is available to Field Managers and links directly to the pending quote, including shared link support when applicable.
  * Sits alongside the existing quote view action for approved quotes.
  * No changes to other actions or behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->