### PR TITLE
Use existing project name for change request

### DIFF
--- a/Harvest.Web/Controllers/Api/RequestController.cs
+++ b/Harvest.Web/Controllers/Api/RequestController.cs
@@ -535,7 +535,7 @@ namespace Harvest.Web.Controllers.Api
             }
 
             // TODO: when is name determined? Currently by quote creator but can it be changed?
-            if (string.IsNullOrWhiteSpace(project.Name))
+            if (string.IsNullOrWhiteSpace(newProject.Name))
             {
                 newProject.Name = piName + "-" + project.Start.ToString("MMMMyyyy");
             }


### PR DESCRIPTION
Close Issue #969

Adds a default project name for change requests and handles empty project names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Change Request projects now default to the original project name with a “(Change Request)” suffix for clearer identification.
  - Custom or derived names are preserved and will no longer be overwritten by the PI-based naming.
  - Prevents unintended name changes and ensures consistent, predictable naming for newly created change requests in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->