### PR TITLE
Adds team slug to request creation route

### DIFF
--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
@@ -90,7 +90,7 @@ export const RequestContainer = () => {
       return;
     }
 
-    const request = authenticatedFetch(`/api/Request/Create`, {
+    const request = authenticatedFetch(`/api/${team}/Request/Create`, {
       method: "POST",
       body: JSON.stringify(project),
     });

--- a/Harvest.Web/Controllers/Api/RequestController.cs
+++ b/Harvest.Web/Controllers/Api/RequestController.cs
@@ -423,7 +423,7 @@ namespace Harvest.Web.Controllers.Api
         }
 
         [HttpPost]
-        [Route("/api/{controller}/{action}")]
+        [Route("/api/{team}/{controller}/{action}")]
         public async Task<ActionResult> Create([FromBody] Project project)
         {
             var currentUser = await _userService.GetCurrentUser();
@@ -445,6 +445,10 @@ namespace Harvest.Web.Controllers.Api
             
             // ensure team is set
             var team = await _dbContext.Teams.Where(t => t.Slug == project.Team.Slug).SingleAsync();
+            if(team.Slug != TeamSlug) 
+            {
+                return BadRequest("Team slug in URL and body do not match");
+            }
             newProject.TeamId = team.Id;
 
             if (project.Id > 0)

--- a/Test/TestsControllers/TestsApiControllers/RequestControllerTests.cs
+++ b/Test/TestsControllers/TestsApiControllers/RequestControllerTests.cs
@@ -100,7 +100,7 @@ namespace Test.TestsControllers.TestsApiControllers
             ControllerReflection.MethodExpectedAttribute<HttpPostAttribute>(methodName, countAdjustment + 3, testMessage: "Create");
             ControllerReflection.MethodExpectedAttribute<AsyncStateMachineAttribute>(methodName, countAdjustment + 3);
             var routeAttribute = ControllerReflection.MethodExpectedAttribute<RouteAttribute>(methodName, countAdjustment + 3);
-            routeAttribute.ElementAt(0).Template.ShouldBe("/api/{controller}/{action}");
+            routeAttribute.ElementAt(0).Template.ShouldBe("/api/{team}/{controller}/{action}");
         }
     }
 }


### PR DESCRIPTION
Updates the request creation endpoint to include the team slug, ensuring that requests are properly associated with the correct team.

Adds validation to confirm that the team slug in the URL matches the team slug in the request body, preventing potential misassociations.