### PR TITLE
Grants access to mobile app for FM/Super

### DIFF
--- a/Harvest.Web/ClientApp/src/App.tsx
+++ b/Harvest.Web/ClientApp/src/App.tsx
@@ -216,7 +216,7 @@ function App() {
               <ExpenseEntryContainer isEditMode={false} />
             </ConditionalRoute>
             <ConditionalRoute
-              roles={["Worker"]}
+              roles={["Worker", "FieldManager", "Supervisor"]}
               exact
               path="/:team/mobile/token"
               component={MobileTokenContainer}

--- a/Harvest.Web/ClientApp/src/AppNav.tsx
+++ b/Harvest.Web/ClientApp/src/AppNav.tsx
@@ -67,7 +67,7 @@ export const AppNav = () => {
                     <NavLink href={`/${team}/project`}>All Projects</NavLink>
                   </NavItem>
                 </ShowFor>
-                <ShowFor roles={["Worker"]}>
+                <ShowFor roles={["Worker", "FieldManager", "Supervisor"]}>
                   <NavItem>
                     <NavLink href={`/${team}/mobile/token`}>App Link</NavLink>
                   </NavItem>

--- a/Harvest.Web/Controllers/Api/LinkController.cs
+++ b/Harvest.Web/Controllers/Api/LinkController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -32,9 +33,11 @@ namespace Harvest.Web.Controllers.Api
         {
             var user = await _userService.GetCurrentUser();
 
+            var validRoles = new List<string> { Role.Codes.Worker, Role.Codes.FieldManager, Role.Codes.Supervisor };
+
 
             var permission = await _dbContext.Permissions
-                .Where(p => p.UserId == user.Id && p.Team.Slug == TeamSlug && p.Role.Name == Role.Codes.Worker)
+                .Where(p => p.UserId == user.Id && p.Team.Slug == TeamSlug && validRoles.Contains(p.Role.Name))
                 .SingleOrDefaultAsync();
             if (permission == null)
             {


### PR DESCRIPTION
Extends access to the mobile app link to Field Managers and Supervisors.

Previously, only Workers could access the mobile app through the generated token link. This change allows Field Managers and Supervisors to use the mobile app as well.