### PR TITLE
Adds close button to project requirements modal

### DIFF
--- a/Harvest.Web/ClientApp/src/Shared/ProjectHeader.tsx
+++ b/Harvest.Web/ClientApp/src/Shared/ProjectHeader.tsx
@@ -105,7 +105,14 @@ export const ProjectHeader = (props: Props) => {
             <p className="lede">Requirements</p>
             {projectReqs}
             <Modal isOpen={modal} toggle={toggleModal}>
-              <ModalHeader toggle={toggleModal}>
+              <ModalHeader
+                toggle={toggleModal}
+                close={
+                  <button className="close" onClick={toggleModal}>
+                    &times;
+                  </button>
+                }
+              >
                 Project Requirements
               </ModalHeader>
               <ModalBody>{project.requirements}</ModalBody>


### PR DESCRIPTION
Improves the usability of the project requirements modal by adding a visible close button in the header. This allows users to easily dismiss the modal, especially on smaller screens where the header's "X" might be less prominent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the modal header to use a custom-rendered close button for a more consistent look and feel across the app.
  - The close control now appears as a dedicated button within the header while preserving the same closing behavior and title display.
  - No functional changes; this is a visual/UI refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->