### PR TITLE
Loads quote from pending change request

### DIFF
--- a/Harvest.Web/Controllers/Api/QuoteController.cs
+++ b/Harvest.Web/Controllers/Api/QuoteController.cs
@@ -90,6 +90,16 @@ namespace Harvest.Web.Controllers.Api
                 model.Quote.ApprovedOn = project.Quote?.ApprovedOn;
             }
 
+            if(project.QuoteId == null && project.OriginalProjectId != null)
+            {
+                // Ok, we want to try to view the pending change request's quote.
+                var newQuote = await _dbContext.Quotes.SingleOrDefaultAsync(q => q.ProjectId == project.Id);
+                if(newQuote != null)
+                {
+                    model.Quote = QuoteDetail.Deserialize(newQuote.Text);
+                }
+            }
+
             return Ok(model);
         }
 


### PR DESCRIPTION
If a project is a change request and doesn't have an associated quote, attempts to load the quote associated with the change request itself. This allows users to view the quote for the pending change before it is approved.

This can happen with a change request that hasn't been approved yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approved quotes now display the pending change request’s quote when no current quote exists but an original project is linked.
  * Eliminates empty or missing quote scenarios in approved views by automatically loading the relevant pending quote.
  * Improves consistency of the Approved endpoint response, ensuring the Quote field is populated when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->