### PR TITLE
rabbit suggestion  -- Updates quote calculation on year change

### DIFF
--- a/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/QuoteContainer.tsx
@@ -174,7 +174,7 @@ export const QuoteContainer = () => {
         grandTotal: activitiesTotal + acreageTotal,
       };
     });
-  }, [quote.activities, quote.acreageRate, quote.acres]);
+  }, [quote.activities, quote.acreageRate, quote.acres, quote.years]);
 
   const cropArray = useMemo(
     () => (project ? project.crop.split(",") : []),


### PR DESCRIPTION
Recalculates the quote grand total when the number of years changes.

The grand total calculation was previously only updated when activities, acreage rate, or acres changed. This change adds `quote.years` to the dependency array of the `useMemo` hook to ensure the grand total is recalculated when the number of years is updated.