### PR TITLE
Adds recent expenses endpoint for mobile app

### DIFF
--- a/Harvest.Web/Controllers/Api/MobileController.cs
+++ b/Harvest.Web/Controllers/Api/MobileController.cs
@@ -96,6 +96,30 @@ namespace Harvest.Web.Controllers.Api
         }
 
         [HttpGet]
+        [Route("api/mobile/recentexpenses")]
+        public async Task<IActionResult> RecentExpenses()
+        {
+            var teamId = TeamId;
+            if (teamId == null)
+            {
+                return Unauthorized("Team information not found");
+            }
+            var user = await _userService.GetCurrentUser();
+            if (user == null)
+            {
+                return Unauthorized("User information not found");
+            }
+            //Find my last 5 expenses I have entered.
+            var recentExpenses = await _dbContext.Expenses
+                .AsNoTracking()
+                .Where(e => e.Project.TeamId == teamId && e.CreatedById == user.Id && e.Project.IsActive && e.Project.Status == Project.Statuses.Active)
+                .OrderByDescending(e => e.CreatedOn)
+                .Take(5)
+                .ToListAsync();
+            return Ok(recentExpenses);
+        }
+
+        [HttpGet]
         [Route("api/mobile/activerates")]
         public async Task<ActionResult> ActiveRates()
         {


### PR DESCRIPTION
Implements an endpoint to retrieve the last 5 expenses entered by a user for the mobile application. This allows users to quickly view their recent expense submissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a mobile API endpoint to retrieve a user’s five most recent expenses.
  - Results are limited to the current team, the signed-in user, active projects, and active statuses.
  - Expenses are returned in descending order by creation date.
  - Responds with Unauthorized when team or user context is missing; otherwise returns the recent expenses list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->