### PR TITLE
Removes mobile app link from navigation

### DIFF
--- a/Harvest.Web/ClientApp/src/AppNav.tsx
+++ b/Harvest.Web/ClientApp/src/AppNav.tsx
@@ -67,11 +67,6 @@ export const AppNav = () => {
                     <NavLink href={`/${team}/project`}>All Projects</NavLink>
                   </NavItem>
                 </ShowFor>
-                <ShowFor roles={["Worker", "FieldManager", "Supervisor"]}>
-                  <NavItem>
-                    <NavLink href={`/${team}/mobile/token`}>App Link</NavLink>
-                  </NavItem>
-                </ShowFor>
                 <ShowFor roles={["Worker"]}>
                   <NavItem>
                     <NavLink href={`/${team}/expense/entry`}>Expenses</NavLink>


### PR DESCRIPTION
The mobile app link is no longer needed in the main navigation for Workers, Field Managers, and Supervisors. This change simplifies the navigation menu and removes an unnecessary option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an erroneous navigation link from the All Projects section that was being incorrectly displayed for specific user roles, improving overall navigation clarity and ensuring users see only relevant navigation options appropriate to their access level and responsibilities within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->