### PR TITLE
Applies markup to expenses based on flag

### DIFF
--- a/Harvest.Web/Controllers/Api/MobileController.cs
+++ b/Harvest.Web/Controllers/Api/MobileController.cs
@@ -349,6 +349,9 @@ namespace Harvest.Web.Controllers.Api
                 {
                     var rate = allRates.Single(a => a.Id == expense.RateId);
 
+                    var markupPrice = expense.Markup ? rate.Price * 1.2m : rate.Price;
+                    //TODO: Mobile needs to send the markup flag for Other rates.
+
                     expense.Approved = false; //Don't trust what we pass, or use a model instead?
                     expense.ApprovedById = null;
                     expense.ApprovedOn = null;
@@ -361,7 +364,7 @@ namespace Harvest.Web.Controllers.Api
                     expense.Account = rate.Account;
                     expense.Price = rate.Price;
                     expense.Type = rate.Type;
-                    expense.Total = Math.Round(rate.Price * expense.Quantity, 2, MidpointRounding.ToZero);
+                    expense.Total = Math.Round(markupPrice * expense.Quantity, 2, MidpointRounding.AwayFromZero); //was MidpointRounding.ToZero
                     expense.IsPassthrough = rate.IsPassthrough;
                     if (autoApprove)
                     {


### PR DESCRIPTION
Updates expense total calculation to include markup when the markup flag is true. Uses `MidpointRounding.AwayFromZero` for rounding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added markup pricing calculation for mobile expenses when applicable.

* **Bug Fixes**
  * Improved price rounding methodology for more accurate total calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->