### PR TITLE
Excludes cancelled invoices from checks

### DIFF
--- a/Harvest.Core/Services/InvoiceService.cs
+++ b/Harvest.Core/Services/InvoiceService.cs
@@ -151,9 +151,10 @@ namespace Harvest.Core.Services
                 .Include(e => e.Invoice)
                 .Where(e => e.Approved && e.ProjectId == projectId)
                 .ToArrayAsync();
-            var totalExpenses = allExpenses.Sum(e => e.Total);
+            var totalExpenses = allExpenses.Where(e => e.Invoice == null || e.Invoice.Status != Invoice.Statuses.Cancelled).Sum(e => e.Total);
             if (totalExpenses > project.QuoteTotal)
             {
+                //I'm filtering out cancelled invoices above, but it doesn't hurt having this check here too.
                 var billedTotal = allExpenses
                     .Where(e => e.InvoiceId != null && e.Invoice.Status != Invoice.Statuses.Cancelled)
                     .Sum(e => e.Total);


### PR DESCRIPTION
Ensures that cancelled invoices are excluded when checking for existing invoices in the current month and when calculating the billed total expenses against the project quote. This prevents errors and inconsistencies in invoice creation and quote management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invoice creation to prevent multiple non-cancelled invoices from being created in the same billing month.
  * Corrected expense calculations to consistently exclude cancelled invoices from total expense and billed amount reports, ensuring accurate financial data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->