### PR TITLE
Filters out cancelled invoices from reports

### DIFF
--- a/Harvest.Web/Models/ReportModels/HistoricalRateActivityModel.cs
+++ b/Harvest.Web/Models/ReportModels/HistoricalRateActivityModel.cs
@@ -48,8 +48,8 @@ namespace Harvest.Web.Models.ReportModels
                 Description = rate.Description,
                 Account = rate.Account,
                 Price = rate.Price,
-                TotalQuantity = rate.Expenses.Where(a => a.CreatedOn >= start && a.CreatedOn <= end).Sum(a => a.Quantity),
-                TotalAmount = rate.Expenses.Where(a => a.CreatedOn >= start && a.CreatedOn <= end).Sum(a => a.Total)
+                TotalQuantity = rate.Expenses.Where(a => a.CreatedOn >= start && a.CreatedOn <= end && a.Invoice != null && a.Invoice.Status != Invoice.Statuses.Cancelled).Sum(a => a.Quantity),
+                TotalAmount = rate.Expenses.Where(a => a.CreatedOn >= start && a.CreatedOn <= end && a.Invoice != null && a.Invoice.Status != Invoice.Statuses.Cancelled).Sum(a => a.Total)
             };
         }
     }

--- a/Harvest.Web/Models/ReportModels/ProjectsListModel.cs
+++ b/Harvest.Web/Models/ReportModels/ProjectsListModel.cs
@@ -70,7 +70,7 @@ namespace Harvest.Web.Models.ReportModels
                 CreatedOn = project.CreatedOn.ToPacificTime(),
                 PrincipalInvestigatorName = project.PrincipalInvestigator.Name,
                 PrincipalInvestigatorEmail = project.PrincipalInvestigator.Email,
-                InvoiceTotal = project.Invoices.Sum(i => i.Total)
+                InvoiceTotal = project.Invoices.Where(a => a.Status != Invoice.Statuses.Cancelled).Sum(i => i.Total)
             };            
         }
 


### PR DESCRIPTION
Ensures that reports accurately reflect financial data by excluding information from cancelled invoices when calculating totals for historical rate activity and project lists. This prevents skewed results and provides a more precise view of financial performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Historical Rate Activity report to exclude cancelled invoices from quantity and amount totals.
  * Fixed Projects List report to exclude cancelled invoices from invoice totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->