### PR TITLE
Improves mobile authorization error message.

### DIFF
--- a/Harvest.Web/ClientApp/src/Mobile/MobileTokenContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Mobile/MobileTokenContainer.tsx
@@ -69,14 +69,15 @@ export const MobileTokenContainer = () => {
         setIsAuthorized(true);
         toast.success("Mobile app authorized successfully!");
       } else {
+        const errorText = await response.text();
         const env = window.location.origin.startsWith(
           "https://harvest.caes.ucdavis.edu"
         )
           ? "production"
           : "test";
         const permissionError = `You do not have permissions in ${env} in team ${team} to use the mobile app.`;
-        setError(permissionError);
-        toast.error(permissionError);
+        setError(errorText || permissionError);
+        toast.error(errorText || permissionError);
       }
     } catch (err) {
       const errorMessage =

--- a/Harvest.Web/Controllers/Api/LinkController.cs
+++ b/Harvest.Web/Controllers/Api/LinkController.cs
@@ -41,7 +41,7 @@ namespace Harvest.Web.Controllers.Api
                 .SingleOrDefaultAsync();
             if (permission == null)
             {
-                return NotFound();
+                return NotFound($"No valid permission found for team {TeamSlug}"); 
             }
             permission.Token = Guid.NewGuid();
             permission.TokenExpires = DateTime.UtcNow.AddMinutes(5);


### PR DESCRIPTION
Provides a more informative error message when a user lacks permissions to authorize the mobile app.

The message now includes the environment (production/test) and the team name to help users understand the
authorization failure reason.

<img width="1417" height="934" alt="image" src="https://github.com/user-attachments/assets/c3c259cc-dc87-4f23-bb77-491f1c9187ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile app authorization errors now show a clear, environment-aware message indicating which environment and team lack permissions.
  * API responses now return a clearer message when no valid permission is found for a team, improving troubleshooting for missing access.

* **Style**
  * Heading layout fixed so the "Mobile Token Generator" title displays on a single line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->