### PR TITLE
Prevents multiple concurrent change requests for a project

### DIFF
--- a/Harvest.Core/Domain/Project.cs
+++ b/Harvest.Core/Domain/Project.cs
@@ -223,6 +223,13 @@ namespace Harvest.Core.Domain
             public const string Canceled = "Canceled";
             public const string ChangeApplied = "ChangeApplied"; //Change Request was approved and applied, this is no longer an active project.
 
+            public static readonly IReadOnlyList<string> OpenChangeRequestStatuses = new[]
+            {
+                PendingApproval,
+                ChangeRequested,
+                QuoteRejected,
+            };
+
             public static List<string> TypeList = new List<string>
             {
                 Requested,

--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.test.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, unmountComponentAtNode } from "react-dom";
 import { MemoryRouter, Route } from "react-router-dom";
-import { act } from "react-dom/test-utils";
+import { act, Simulate } from "react-dom/test-utils";
 
 import { RequestContainer } from "./RequestContainer";
 import { fakeAppContext, fakeCrops, fakeProject } from "../Test/mockData";
@@ -29,13 +29,21 @@ beforeEach(() => {
     json: () => Promise.resolve(fakeCrops.filter((c) => c.type === "Row")),
   });
 
+  const pendingChangeRequestsResponse = Promise.resolve({
+    status: 200,
+    ok: true,
+    json: () => Promise.resolve([]),
+  });
+
   (global as any).Harvest = fakeAppContext;
   // setup a DOM element as a render target
   container = document.createElement("div");
   document.body.appendChild(container);
   global.fetch = jest.fn().mockImplementation((x) =>
     responseMap(x, {
-      "/api/team1/Project": projectResponse,
+      "/api/team1/Project/GetPendingChangeRequests/":
+        pendingChangeRequestsResponse,
+      "/api/team1/Project/Get/": projectResponse,
       "/api/File/": fileResponse,
       "/api/Crop": cropResponse,
     })
@@ -119,6 +127,75 @@ describe("Request Container", () => {
     expect(cropType?.innerHTML).toContain("");
     expect(vegetable?.textContent).toContain("");
     expect(PI[1]?.value).toContain("");
+    expect(button).toContainHTML("disabled=");
+  });
+
+  it("Shows a warning and keeps create change request disabled when one already exists", async () => {
+    const pendingChangeRequestsResponse = Promise.resolve({
+      status: 200,
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: 42,
+            status: "ChangeRequested",
+            name: "Tomato Update",
+          },
+        ]),
+    });
+
+    global.fetch = jest.fn().mockImplementation((x) =>
+      responseMap(x, {
+        "/api/team1/Project/GetPendingChangeRequests/":
+          pendingChangeRequestsResponse,
+        "/api/team1/Project/Get/": Promise.resolve({
+          status: 200,
+          ok: true,
+          json: () => Promise.resolve(fakeProject),
+        }),
+        "/api/File/": Promise.resolve({
+          status: 200,
+          ok: true,
+          text: () => Promise.resolve("file 1"),
+        }),
+        "/api/Crop": Promise.resolve({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve(fakeCrops.filter((c) => c.type === "Row")),
+        }),
+      })
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={["team1/request/create/3"]}>
+          <Route path=":team/request/create/:projectId?">
+            <RequestContainer />
+          </Route>
+        </MemoryRouter>,
+        container
+      );
+    });
+
+    const requirements = container.querySelector(
+      "#requirements"
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      Simulate.change(requirements, {
+        target: { value: "Updated requirements" } as unknown as EventTarget,
+      });
+    });
+
+    const button = container.querySelector("#Request-Button");
+    const warning = container.querySelector(".alert.alert-danger");
+
+    expect(warning?.textContent).toContain(
+      "Only one change request can be created at a time"
+    );
+    expect(warning?.textContent).toContain("Tomato Update");
+    expect(warning?.textContent).toContain("View change request #42");
     expect(button).toContainHTML("disabled=");
   });
 });

--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
@@ -51,7 +51,7 @@ export const RequestContainer = () => {
   >([]);
   const [isCheckingPendingChangeRequests, setIsCheckingPendingChangeRequests] =
     useState(projectId !== undefined);
- 
+
   const {
     context,
     validateAll,
@@ -401,14 +401,31 @@ export const RequestContainer = () => {
               </FormGroup>
               {projectId && hasPendingChangeRequests && (
                 <div className="alert alert-danger" role="alert">
-                  <strong>
-                    Another active change request already exists for this
-                    project.
-                  </strong>{" "}
-                  Only one change request can be created at a time. Please open
-                  the existing change request below instead of creating a new
-                  one.
-                  <ul className="mb-0 mt-2">
+                  <p className="mb-2">
+                    <strong>
+                      Another active change request already exists for this
+                      project.
+                    </strong>
+                  </p>
+                  <p className="mb-2">
+                    Only one change request can be created at a time. Please
+                    open the existing change request below instead of creating a
+                    new one.
+                  </p>
+                  <p className="mb-2">
+                    If a quote for this change is rejected, let the Field
+                    Manager know to cancel the pending change request and you
+                    can create a new one.
+                  </p>
+                  <p className="mb-2">
+                    If the quote has been created, either approve or reject the
+                    change request to proceed.
+                  </p>
+                  <p className="mb-2">
+                    If you need to change the end date, that will need a new
+                    change request once the current one is resolved.
+                  </p>
+                  <ul className="mb-0">
                     {pendingChangeRequests.map((request) => (
                       <li key={request.id}>
                         <Link to={`/${team}/project/details/${request.id}`}>

--- a/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
+++ b/Harvest.Web/ClientApp/src/Requests/RequestContainer.tsx
@@ -8,9 +8,18 @@ import { FileUpload } from "../Shared/FileUpload";
 import { SearchPerson } from "./SearchPerson";
 import { Crops } from "./Crops";
 import { requestSchema } from "../schemas";
-import { Project, CropType, Team, CommonRouteParams } from "../types";
+import {
+  Project,
+  CropType,
+  Team,
+  CommonRouteParams,
+  PendingChangeRequest,
+} from "../types";
 import AppContext from "../Shared/AppContext";
-import { usePromiseNotification } from "../Util/Notifications";
+import {
+  genericErrorMessage,
+  usePromiseNotification,
+} from "../Util/Notifications";
 import { ProjectHeader } from "../Shared/ProjectHeader";
 import { useIsMounted } from "../Shared/UseIsMounted";
 import { authenticatedFetch } from "../Util/Api";
@@ -37,7 +46,12 @@ export const RequestContainer = () => {
     principalInvestigator: userDetail,
   } as Project);
   const [originalProject, setOriginalProject] = useState<Project>();
-
+  const [pendingChangeRequests, setPendingChangeRequests] = useState<
+    PendingChangeRequest[]
+  >([]);
+  const [isCheckingPendingChangeRequests, setIsCheckingPendingChangeRequests] =
+    useState(projectId !== undefined);
+ 
   const {
     context,
     validateAll,
@@ -52,36 +66,60 @@ export const RequestContainer = () => {
   } = useInputValidator(requestSchema, project, validatorOptions);
 
   const [notification, setNotification] = usePromiseNotification();
+  const hasPendingChangeRequests = pendingChangeRequests.length > 0;
 
   const getIsMounted = useIsMounted();
   useEffect(() => {
     // load original request if this is a change request
     const cb = async () => {
-      const response = await authenticatedFetch(
-        `/api/${team}/Project/Get/${projectId}`
-      );
+      try {
+        setIsCheckingPendingChangeRequests(true);
 
-      if (response.ok) {
-        const proj: Project = await response.json();
+        const [response, pendingResponse] = await Promise.all([
+          authenticatedFetch(`/api/${team}/Project/Get/${projectId}`),
+          authenticatedFetch(
+            `/api/${team}/Project/GetPendingChangeRequests/${projectId}`
+          ),
+        ]);
 
-        if (getIsMounted()) {
-          setProject({
-            ...proj,
-            start: new Date(proj.start),
-            end: new Date(proj.end),
-            requirements: `Original: ${proj.requirements}`,
-          });
-          setOriginalProject(proj);
+        if (response.ok) {
+          const proj: Project = await response.json();
+
+          if (getIsMounted()) {
+            setProject({
+              ...proj,
+              start: new Date(proj.start),
+              end: new Date(proj.end),
+              requirements: `Original: ${proj.requirements}`,
+            });
+            setOriginalProject(proj);
+          }
         }
+
+        if (pendingResponse.ok) {
+          const pendingRequests: PendingChangeRequest[] =
+            await pendingResponse.json();
+          getIsMounted() && setPendingChangeRequests(pendingRequests);
+        } else {
+          getIsMounted() && setPendingChangeRequests([]);
+        }
+      } finally {
+        getIsMounted() && setIsCheckingPendingChangeRequests(false);
       }
     };
 
     if (projectId !== undefined) {
       cb();
+    } else {
+      setIsCheckingPendingChangeRequests(false);
     }
   }, [projectId, getIsMounted, team]);
 
   const create = async () => {
+    if (hasPendingChangeRequests) {
+      return;
+    }
+
     // TODO: validation, loading spinner
     // create a new project
     const requestErrors = await validateAll();
@@ -99,10 +137,16 @@ export const RequestContainer = () => {
       setNotification(
         request,
         `Creating Request For ${project.principalInvestigator.name}`,
-        `Request Created For ${project.principalInvestigator.name}`
+        `Request Created For ${project.principalInvestigator.name}`,
+        async (error) => (await error.text()) || genericErrorMessage
       );
     } else {
-      setNotification(request, "Creating Request", "Request Created");
+      setNotification(
+        request,
+        "Creating Request",
+        "Request Created",
+        async (error) => (await error.text()) || genericErrorMessage
+      );
     }
 
     const response = await request;
@@ -132,8 +176,11 @@ export const RequestContainer = () => {
     return project.start && project.end && project.crop && project.requirements;
   }, [project.start, project.end, project.crop, project.requirements]);
 
-  if (projectId !== undefined && project.id === 0) {
-    // if we have a project id but it hasn't loaded yet, wait
+  if (
+    projectId !== undefined &&
+    (project.id === 0 || isCheckingPendingChangeRequests)
+  ) {
+    // if we have a project id but it or the related request check hasn't loaded yet, wait
     return <div>Loading...</div>;
   }
 
@@ -352,6 +399,26 @@ export const RequestContainer = () => {
                 />
                 <InputErrorMessage name="requirements" />
               </FormGroup>
+              {projectId && hasPendingChangeRequests && (
+                <div className="alert alert-danger" role="alert">
+                  <strong>
+                    Another active change request already exists for this
+                    project.
+                  </strong>{" "}
+                  Only one change request can be created at a time. Please open
+                  the existing change request below instead of creating a new
+                  one.
+                  <ul className="mb-0 mt-2">
+                    {pendingChangeRequests.map((request) => (
+                      <li key={request.id}>
+                        <Link to={`/${team}/project/details/${request.id}`}>
+                          View change request #{request.id}: {request.name}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
               <div className="row justify-content-center">
                 <Button
                   id="Request-Button"
@@ -361,6 +428,8 @@ export const RequestContainer = () => {
                   disabled={
                     !isFilledIn ||
                     notification.pending ||
+                    isCheckingPendingChangeRequests ||
+                    hasPendingChangeRequests ||
                     formErrorCount > 0 ||
                     !formIsDirty
                   }

--- a/Harvest.Web/Controllers/Api/ProjectController.cs
+++ b/Harvest.Web/Controllers/Api/ProjectController.cs
@@ -186,8 +186,14 @@ namespace Harvest.Web.Controllers.Api
         [HttpGet]
         public async Task<ActionResult> GetPendingChangeRequests(int projectId)
         {
-
-            var projects = await _dbContext.Projects.Where(a => a.Team.Slug == TeamSlug && a.OriginalProjectId == projectId && a.IsActive && (a.Status == Project.Statuses.PendingApproval || a.Status == Project.Statuses.ChangeRequested || a.Status == Project.Statuses.QuoteRejected)).Select(ProjectChangeRequestModel.Projection()).ToListAsync();
+            var projects = await _dbContext.Projects
+                .Where(a =>
+                    a.Team.Slug == TeamSlug &&
+                    a.OriginalProjectId == projectId &&
+                    a.IsActive &&
+                    Project.Statuses.OpenChangeRequestStatuses.Contains(a.Status))
+                .Select(ProjectChangeRequestModel.Projection())
+                .ToListAsync();
             return Ok(projects);
         }
 

--- a/Harvest.Web/Controllers/Api/RequestController.cs
+++ b/Harvest.Web/Controllers/Api/RequestController.cs
@@ -481,6 +481,21 @@ namespace Harvest.Web.Controllers.Api
                     }
                 }
 
+                var existingChangeRequestIds = await _dbContext.Projects
+                    .Where(a =>
+                        a.Team.Slug == TeamSlug &&
+                        a.OriginalProjectId == project.Id &&
+                        a.IsActive &&
+                        Project.Statuses.OpenChangeRequestStatuses.Contains(a.Status))
+                    .Select(a => a.Id)
+                    .ToListAsync();
+
+                if (existingChangeRequestIds.Any())
+                {
+                    return BadRequest(
+                        $"Only one active change request can be created at a time for project {project.Id}. Existing change request ID(s): {string.Join(", ", existingChangeRequestIds)}.");
+                }
+
                 changeRequest = true;
                 newProject.UpdateStatus(Project.Statuses.ChangeRequested);
                 newProject.OriginalProjectId = project.Id;


### PR DESCRIPTION
Adds logic to both the UI and API to ensure only one active change request can exist for a project at a time. The UI now displays a warning linking to existing requests and disables the submission button, while the API includes a server-side check to block duplicate requests.

Server Side Check (Concurrency) :
<img width="1695" height="480" alt="image" src="https://github.com/user-attachments/assets/7b93375c-9f9f-4599-bbbf-18f2320d11f4" />

Need to adjust the message here, but looks:
<img width="1582" height="862" alt="image" src="https://github.com/user-attachments/assets/00181ef0-9f27-4dec-858a-34ae3f26c12b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and display of pending change requests, with direct links to view existing requests.
  * Submit button now disables while checking for pending change requests or when any exist.

* **Bug Fixes**
  * Prevents users from creating new change requests when one already exists for the same project, with an error message indicating the conflicting request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->