### PR TITLE
Implement capped expense markup and standardize quote calculations

### DIFF
--- a/Harvest.Core/Utilities/ExpenseCalculations.cs
+++ b/Harvest.Core/Utilities/ExpenseCalculations.cs
@@ -9,32 +9,10 @@ namespace Harvest.Core.Utilities
         public const decimal MarkupRate = 0.20m;
         public const decimal MarkupCap = 1000m;
 
-        public static decimal CalculateMarkupAmount(decimal baseTotal, bool applyMarkup)
-        {
-            if (!applyMarkup || baseTotal <= 0)
-            {
-                return 0;
-            }
-
-            return RoundCurrency(Math.Min(baseTotal, MarkupCap) * MarkupRate);
-        }
-
         public static decimal CalculateExpenseTotal(decimal rate, decimal quantity, bool applyMarkup)
         {
             var baseTotal = rate * quantity;
             return RoundCurrency(baseTotal + CalculateMarkupAmount(baseTotal, applyMarkup));
-        }
-
-        public static double CalculateWorkItemTotal(WorkItem workItem, decimal adjustment)
-        {
-            if (workItem == null)
-            {
-                throw new ArgumentNullException(nameof(workItem));
-            }
-
-            var adjustedRate = (decimal)workItem.Rate + (((decimal)workItem.Rate * adjustment) / 100m);
-            var baseTotal = adjustedRate * (decimal)workItem.Quantity;
-            return (double)RoundCurrency(baseTotal + CalculateMarkupAmount(baseTotal, workItem.Markup));
         }
 
         public static void NormalizeQuoteDetail(QuoteDetail quoteDetail)
@@ -102,6 +80,28 @@ namespace Harvest.Core.Utilities
         private static decimal RoundCurrency(decimal value)
         {
             return Math.Round(value, 2, MidpointRounding.AwayFromZero);
+        }
+
+        private static decimal CalculateMarkupAmount(decimal baseTotal, bool applyMarkup)
+        {
+            if (!applyMarkup || baseTotal <= 0)
+            {
+                return 0;
+            }
+
+            return RoundCurrency(Math.Min(baseTotal, MarkupCap) * MarkupRate);
+        }
+
+        private static double CalculateWorkItemTotal(WorkItem workItem, decimal adjustment)
+        {
+            if (workItem == null)
+            {
+                throw new ArgumentNullException(nameof(workItem));
+            }
+
+            var adjustedRate = (decimal)workItem.Rate + (((decimal)workItem.Rate * adjustment) / 100m);
+            var baseTotal = adjustedRate * (decimal)workItem.Quantity;
+            return (double)RoundCurrency(baseTotal + CalculateMarkupAmount(baseTotal, workItem.Markup));
         }
     }
 }

--- a/Harvest.Core/Utilities/ExpenseCalculations.cs
+++ b/Harvest.Core/Utilities/ExpenseCalculations.cs
@@ -43,38 +43,45 @@ namespace Harvest.Core.Utilities
                         continue;
                     }
 
-                    workItem.Total = CalculateWorkItemTotal(workItem, activity.Adjustment);
-                    activityTotal += (decimal)workItem.Total;
+                    var workItemTotal = CalculateWorkItemTotal(workItem, activity.Adjustment);
+                    workItem.Total = (double)workItemTotal;
+                    activityTotal += workItemTotal;
 
                     switch (workItem.Type)
                     {
                         case Rate.Types.Labor:
-                            laborTotal += (decimal)workItem.Total;
+                            laborTotal += workItemTotal;
                             break;
                         case Rate.Types.Equipment:
-                            equipmentTotal += (decimal)workItem.Total;
+                            equipmentTotal += workItemTotal;
                             break;
                         case Rate.Types.Other:
-                            otherTotal += (decimal)workItem.Total;
+                            otherTotal += workItemTotal;
                             break;
                     }
                 }
 
-                activity.Total = (double)RoundCurrency(activityTotal);
-                activitiesTotal += (decimal)activity.Total;
+                var roundedActivityTotal = RoundCurrency(activityTotal);
+                activity.Total = (double)roundedActivityTotal;
+                activitiesTotal += roundedActivityTotal;
             }
 
-            quoteDetail.AcreageTotal = (double)RoundCurrency(
+            var acreageTotal = RoundCurrency(
                 (decimal)quoteDetail.AcreageRate *
                 (decimal)quoteDetail.Acres *
                 quoteDetail.Years);
-            quoteDetail.ActivitiesTotal = (double)RoundCurrency(activitiesTotal);
-            quoteDetail.LaborTotal = (double)RoundCurrency(laborTotal);
-            quoteDetail.EquipmentTotal = (double)RoundCurrency(equipmentTotal);
-            quoteDetail.OtherTotal = (double)RoundCurrency(otherTotal);
-            quoteDetail.GrandTotal = (double)RoundCurrency(
-                (decimal)quoteDetail.AcreageTotal +
-                (decimal)quoteDetail.ActivitiesTotal);
+            var roundedActivitiesTotal = RoundCurrency(activitiesTotal);
+            var roundedLaborTotal = RoundCurrency(laborTotal);
+            var roundedEquipmentTotal = RoundCurrency(equipmentTotal);
+            var roundedOtherTotal = RoundCurrency(otherTotal);
+            var grandTotal = RoundCurrency(acreageTotal + roundedActivitiesTotal);
+
+            quoteDetail.AcreageTotal = (double)acreageTotal;
+            quoteDetail.ActivitiesTotal = (double)roundedActivitiesTotal;
+            quoteDetail.LaborTotal = (double)roundedLaborTotal;
+            quoteDetail.EquipmentTotal = (double)roundedEquipmentTotal;
+            quoteDetail.OtherTotal = (double)roundedOtherTotal;
+            quoteDetail.GrandTotal = (double)grandTotal;
         }
 
         private static decimal RoundCurrency(decimal value)
@@ -92,7 +99,7 @@ namespace Harvest.Core.Utilities
             return RoundCurrency(Math.Min(baseTotal, MarkupCap) * MarkupRate);
         }
 
-        private static double CalculateWorkItemTotal(WorkItem workItem, decimal adjustment)
+        private static decimal CalculateWorkItemTotal(WorkItem workItem, decimal adjustment)
         {
             if (workItem == null)
             {
@@ -101,7 +108,7 @@ namespace Harvest.Core.Utilities
 
             var adjustedRate = (decimal)workItem.Rate + (((decimal)workItem.Rate * adjustment) / 100m);
             var baseTotal = adjustedRate * (decimal)workItem.Quantity;
-            return (double)RoundCurrency(baseTotal + CalculateMarkupAmount(baseTotal, workItem.Markup));
+            return RoundCurrency(baseTotal + CalculateMarkupAmount(baseTotal, workItem.Markup));
         }
     }
 }

--- a/Harvest.Core/Utilities/ExpenseCalculations.cs
+++ b/Harvest.Core/Utilities/ExpenseCalculations.cs
@@ -1,0 +1,97 @@
+using System;
+using Harvest.Core.Domain;
+using Harvest.Core.Models;
+
+namespace Harvest.Core.Utilities
+{
+    public static class ExpenseCalculations
+    {
+        public const decimal MarkupRate = 0.20m;
+        public const decimal MarkupCap = 1000m;
+
+        public static decimal CalculateMarkupAmount(decimal baseTotal, bool applyMarkup)
+        {
+            if (!applyMarkup || baseTotal <= 0)
+            {
+                return 0;
+            }
+
+            return RoundCurrency(Math.Min(baseTotal, MarkupCap) * MarkupRate);
+        }
+
+        public static decimal CalculateExpenseTotal(decimal rate, decimal quantity, bool applyMarkup)
+        {
+            var baseTotal = rate * quantity;
+            return RoundCurrency(baseTotal + CalculateMarkupAmount(baseTotal, applyMarkup));
+        }
+
+        public static double CalculateWorkItemTotal(WorkItem workItem, decimal adjustment)
+        {
+            if (workItem == null)
+            {
+                throw new ArgumentNullException(nameof(workItem));
+            }
+
+            var adjustedRate = (decimal)workItem.Rate + (((decimal)workItem.Rate * adjustment) / 100m);
+            var baseTotal = adjustedRate * (decimal)workItem.Quantity;
+            return (double)RoundCurrency(baseTotal + CalculateMarkupAmount(baseTotal, workItem.Markup));
+        }
+
+        public static void NormalizeQuoteDetail(QuoteDetail quoteDetail)
+        {
+            if (quoteDetail == null)
+            {
+                throw new ArgumentNullException(nameof(quoteDetail));
+            }
+
+            decimal activitiesTotal = 0;
+            decimal laborTotal = 0;
+            decimal equipmentTotal = 0;
+            decimal otherTotal = 0;
+
+            foreach (var activity in quoteDetail.Activities ?? Array.Empty<Activity>())
+            {
+                decimal activityTotal = 0;
+
+                foreach (var workItem in activity.WorkItems ?? Array.Empty<WorkItem>())
+                {
+                    workItem.Total = CalculateWorkItemTotal(workItem, activity.Adjustment);
+                    activityTotal += (decimal)workItem.Total;
+
+                    switch (workItem.Type)
+                    {
+                        case Rate.Types.Labor:
+                            laborTotal += (decimal)workItem.Total;
+                            break;
+                        case Rate.Types.Equipment:
+                            equipmentTotal += (decimal)workItem.Total;
+                            break;
+                        case Rate.Types.Other:
+                            otherTotal += (decimal)workItem.Total;
+                            break;
+                    }
+                }
+
+                activity.Total = (double)RoundCurrency(activityTotal);
+                activitiesTotal += (decimal)activity.Total;
+            }
+
+            quoteDetail.AcreageTotal = (double)RoundCurrency(
+                (decimal)quoteDetail.AcreageRate *
+                (decimal)quoteDetail.Acres *
+                quoteDetail.Years);
+            quoteDetail.ActivitiesTotal = (double)RoundCurrency(activitiesTotal);
+            quoteDetail.LaborTotal = (double)RoundCurrency(laborTotal);
+            quoteDetail.EquipmentTotal = (double)RoundCurrency(equipmentTotal);
+            quoteDetail.OtherTotal = (double)RoundCurrency(otherTotal);
+            quoteDetail.GrandTotal = (double)RoundCurrency(
+                (decimal)quoteDetail.AcreageTotal +
+                (decimal)quoteDetail.ActivitiesTotal);
+        }
+
+        private static decimal RoundCurrency(decimal value)
+        {
+            return Math.Round(value, 2, MidpointRounding.AwayFromZero);
+        }
+    }
+}

--- a/Harvest.Core/Utilities/ExpenseCalculations.cs
+++ b/Harvest.Core/Utilities/ExpenseCalculations.cs
@@ -51,10 +51,20 @@ namespace Harvest.Core.Utilities
 
             foreach (var activity in quoteDetail.Activities ?? Array.Empty<Activity>())
             {
+                if (activity == null)
+                {
+                    continue;
+                }
+
                 decimal activityTotal = 0;
 
                 foreach (var workItem in activity.WorkItems ?? Array.Empty<WorkItem>())
                 {
+                    if (workItem == null)
+                    {
+                        continue;
+                    }
+
                     workItem.Total = CalculateWorkItemTotal(workItem, activity.Adjustment);
                     activityTotal += (decimal)workItem.Total;
 

--- a/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
+++ b/Harvest.Web/ClientApp/src/Quotes/WorkItemsForm.tsx
@@ -263,7 +263,8 @@ export const WorkItemsForm = (props: WorkItemsFormProps) => {
             <div className="col-2 col-md-2">
               <label id="markupLabel">Markup</label>
               <UncontrolledTooltip placement="right" target="markupLabel">
-                Adds a 20% parts markup to the total price
+                Adds a 20% markup on the first $1,000 of this expense, up to
+                $200 maximum
               </UncontrolledTooltip>
             </div>
           </>

--- a/Harvest.Web/ClientApp/src/Util/Calculations.test.ts
+++ b/Harvest.Web/ClientApp/src/Util/Calculations.test.ts
@@ -1,0 +1,40 @@
+import {
+  calculateAdjustedTotal,
+  calculateMarkupAmount,
+} from "./Calculations";
+import { WorkItemImpl } from "../types";
+
+describe("calculateAdjustedTotal", () => {
+  it("adds 20 percent markup when the expense total is below the cap", () => {
+    const workItem = new WorkItemImpl(1, 1, "Other");
+    workItem.rate = 450;
+    workItem.quantity = 1;
+    workItem.markup = true;
+
+    expect(calculateAdjustedTotal(workItem, 0)).toBe(540);
+  });
+
+  it("caps markup at 200 dollars per expense", () => {
+    const workItem = new WorkItemImpl(1, 1, "Other");
+    workItem.rate = 900;
+    workItem.quantity = 10;
+    workItem.markup = true;
+
+    expect(calculateAdjustedTotal(workItem, 0)).toBe(9200);
+  });
+
+  it("applies the cap after annual adjustment changes the base total", () => {
+    const workItem = new WorkItemImpl(1, 1, "Other");
+    workItem.rate = 100;
+    workItem.quantity = 5;
+    workItem.markup = true;
+
+    expect(calculateAdjustedTotal(workItem, 10)).toBe(660);
+  });
+});
+
+describe("calculateMarkupAmount", () => {
+  it("returns zero when markup is not selected", () => {
+    expect(calculateMarkupAmount(1000, false)).toBe(0);
+  });
+});

--- a/Harvest.Web/ClientApp/src/Util/Calculations.test.ts
+++ b/Harvest.Web/ClientApp/src/Util/Calculations.test.ts
@@ -1,7 +1,4 @@
-import {
-  calculateAdjustedTotal,
-  calculateMarkupAmount,
-} from "./Calculations";
+import { calculateAdjustedTotal, calculateMarkupAmount } from "./Calculations";
 import { WorkItemImpl } from "../types";
 
 describe("calculateAdjustedTotal", () => {
@@ -12,6 +9,15 @@ describe("calculateAdjustedTotal", () => {
     workItem.markup = true;
 
     expect(calculateAdjustedTotal(workItem, 0)).toBe(540);
+  });
+
+  it("applies the 200 dollar markup when the base total is exactly at the cap", () => {
+    const workItem = new WorkItemImpl(1, 1, "Other");
+    workItem.rate = 1000;
+    workItem.quantity = 1;
+    workItem.markup = true;
+
+    expect(calculateAdjustedTotal(workItem, 0)).toBe(1200);
   });
 
   it("caps markup at 200 dollars per expense", () => {
@@ -30,6 +36,18 @@ describe("calculateAdjustedTotal", () => {
     workItem.markup = true;
 
     expect(calculateAdjustedTotal(workItem, 10)).toBe(660);
+  });
+
+  it("rounds fractional-cent markup and adjusted totals to two decimals", () => {
+    const workItem = new WorkItemImpl(1, 1, "Other");
+    workItem.rate = 16.675;
+    workItem.quantity = 1;
+    workItem.markup = true;
+
+    expect(calculateMarkupAmount(workItem.rate * workItem.quantity, true)).toBe(
+      3.34
+    );
+    expect(calculateAdjustedTotal(workItem, 0)).toBe(20.02);
   });
 });
 

--- a/Harvest.Web/ClientApp/src/Util/Calculations.ts
+++ b/Harvest.Web/ClientApp/src/Util/Calculations.ts
@@ -1,15 +1,28 @@
 import { WorkItem } from "../types";
 
+export const expenseMarkupRate = 0.2;
+export const expenseMarkupCap = 1000;
+
+export const calculateMarkupAmount = (
+  baseTotal: number,
+  applyMarkup: boolean
+) => {
+  if (!applyMarkup || baseTotal <= 0) {
+    return 0;
+  }
+
+  return Math.min(baseTotal, expenseMarkupCap) * expenseMarkupRate;
+};
+
 export const calculateAdjustedTotal = (
   workItem: WorkItem,
   adjustment: number
 ) => {
-  const markup = workItem.markup ? 1.2 : 1;
-  return (
+  const baseTotal =
     (workItem.rate + (workItem.rate * adjustment) / 100.0) *
-    workItem.quantity *
-    markup
-  );
+    workItem.quantity;
+
+  return baseTotal + calculateMarkupAmount(baseTotal, workItem.markup);
 };
 
 export const roundToTwo = (num: number) => {

--- a/Harvest.Web/ClientApp/src/Util/Calculations.ts
+++ b/Harvest.Web/ClientApp/src/Util/Calculations.ts
@@ -11,7 +11,7 @@ export const calculateMarkupAmount = (
     return 0;
   }
 
-  return Math.min(baseTotal, expenseMarkupCap) * expenseMarkupRate;
+  return roundToTwo(Math.min(baseTotal, expenseMarkupCap) * expenseMarkupRate);
 };
 
 export const calculateAdjustedTotal = (
@@ -19,10 +19,11 @@ export const calculateAdjustedTotal = (
   adjustment: number
 ) => {
   const baseTotal =
-    (workItem.rate + (workItem.rate * adjustment) / 100.0) *
-    workItem.quantity;
+    (workItem.rate + (workItem.rate * adjustment) / 100.0) * workItem.quantity;
 
-  return baseTotal + calculateMarkupAmount(baseTotal, workItem.markup);
+  return roundToTwo(
+    baseTotal + calculateMarkupAmount(baseTotal, workItem.markup)
+  );
 };
 
 export const roundToTwo = (num: number) => {

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -6,6 +6,7 @@ using Harvest.Core.Data;
 using Harvest.Core.Domain;
 using Harvest.Core.Models;
 using Harvest.Core.Services;
+using Harvest.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
@@ -53,10 +54,6 @@ namespace Harvest.Web.Controllers.Api
                     return BadRequest($"Rate with ID of {expense.RateId} is not valid.");
                 }
 
-                //expense.Markup is 20% when true so rate.Price * 1.2
-
-                var markupPrice = expense.Markup ? rate.Price * 1.2m : rate.Price;
-
                 expense.CreatedBy = user;
                 expense.CreatedOn = DateTime.UtcNow;
                 expense.ProjectId = projectId;
@@ -64,7 +61,7 @@ namespace Harvest.Web.Controllers.Api
                 expense.Account = rate.Account;
                 expense.Price = rate.Price;
                 expense.Type = rate.Type;
-                expense.Total = Math.Round(markupPrice * expense.Quantity, 2, MidpointRounding.AwayFromZero); //was MidpointRounding.ToZero
+                expense.Total = ExpenseCalculations.CalculateExpenseTotal(rate.Price, expense.Quantity, expense.Markup);
                 expense.IsPassthrough = rate.IsPassthrough;
                 if (autoApprove)
                 {
@@ -184,11 +181,13 @@ namespace Harvest.Web.Controllers.Api
             existingExpense.Markup = expense.Markup;
             //existingExpense.Rate = expense.Rate; Do not set this as it is a null value in the posted object, ends up deleting the expense.
             existingExpense.RateId = expense.RateId;
-            existingExpense.Price = expense.Price;
-            existingExpense.Total = expense.Total;
+            var existingRate = allRates.Single(a => a.Id == expense.RateId);
+            existingExpense.Price = existingRate.Price;
+            existingExpense.Type = existingRate.Type;
+            existingExpense.Total = ExpenseCalculations.CalculateExpenseTotal(existingRate.Price, expense.Quantity, expense.Markup);
             existingExpense.CreatedOn = DateTime.UtcNow;
-            existingExpense.Account = allRates.Single(a => a.Id == expense.RateId).Account;
-            existingExpense.IsPassthrough = allRates.Single(a => a.Id == expense.RateId).IsPassthrough;
+            existingExpense.Account = existingRate.Account;
+            existingExpense.IsPassthrough = existingRate.IsPassthrough;
             if (existingExpense.Total <= 0)
             {
                 return BadRequest("Maybe the expense was removed. Can't do that.");
@@ -198,12 +197,16 @@ namespace Harvest.Web.Controllers.Api
             var newExpenses = expenses.Where(e => e.Id == 0).ToList();
             foreach (var newExpense in newExpenses)
             {
+                var newRate = allRates.Single(a => a.Id == newExpense.RateId);
                 newExpense.CreatedBy = existingExpense.CreatedBy;
                 newExpense.CreatedOn = DateTime.UtcNow;
                 newExpense.ProjectId = projectId;
                 newExpense.InvoiceId = null;
-                newExpense.Account = allRates.Single(a => a.Id == newExpense.RateId).Account;
-                newExpense.IsPassthrough = allRates.Single(a => a.Id == newExpense.RateId).IsPassthrough;
+                newExpense.Account = newRate.Account;
+                newExpense.Price = newRate.Price;
+                newExpense.Type = newRate.Type;
+                newExpense.Total = ExpenseCalculations.CalculateExpenseTotal(newRate.Price, newExpense.Quantity, newExpense.Markup);
+                newExpense.IsPassthrough = newRate.IsPassthrough;
 
                 ////Ok, new expenses are being created with an edit here, so we need to make sure 
                 //if (isFieldManager)
@@ -214,10 +217,6 @@ namespace Harvest.Web.Controllers.Api
                 //}
 
             }
-
-            //if markup is true, price is rate.Price * 1.2
-            //But we don't have to deal with it here because we are using the client side total
-
             if (newExpenses.Count > 0)
             {
                 _dbContext.Expenses.AddRange(newExpenses);

--- a/Harvest.Web/Controllers/Api/ExpenseController.cs
+++ b/Harvest.Web/Controllers/Api/ExpenseController.cs
@@ -45,11 +45,13 @@ namespace Harvest.Web.Controllers.Api
 
             var user = await _userService.GetCurrentUser();
             var autoApprove = await _userService.HasAnyTeamRoles(TeamSlug, new[] { Role.Codes.FieldManager });
-            var allRates = await _dbContext.Rates.Where(a => a.IsActive).ToListAsync();
+            var allRates = await _dbContext.Rates
+                .Where(a => a.IsActive && a.TeamId == project.TeamId)
+                .ToListAsync();
             foreach (var expense in expenses)
             {
                 var rate = allRates.SingleOrDefault(a => a.Id == expense.RateId);
-                if(rate == null)
+                if (rate == null)
                 {
                     return BadRequest($"Rate with ID of {expense.RateId} is not valid.");
                 }
@@ -160,7 +162,9 @@ namespace Harvest.Web.Controllers.Api
                 return BadRequest("Cannot edit an expense that has been billed.");
             }
 
-            var allRates = await _dbContext.Rates.Where(a => a.IsActive).ToListAsync();
+            var allRates = await _dbContext.Rates
+                .Where(a => a.IsActive && a.TeamId == project.TeamId)
+                .ToListAsync();
 
             if (!isFieldManager)
             {
@@ -222,7 +226,7 @@ namespace Harvest.Web.Controllers.Api
                 _dbContext.Expenses.AddRange(newExpenses);
                 await _historyService.ExpensesCreated(projectId, newExpenses); //TODO: Change to edited?
             }
-            
+
 
             await _dbContext.SaveChangesAsync();
 
@@ -241,7 +245,7 @@ namespace Harvest.Web.Controllers.Api
                 return NotFound();
             }
 
-            if(expense.InvoiceId != null)
+            if (expense.InvoiceId != null)
             {
                 return BadRequest("Cannot delete an expense that has been billed.");
             }

--- a/Harvest.Web/Controllers/Api/MobileController.cs
+++ b/Harvest.Web/Controllers/Api/MobileController.cs
@@ -3,6 +3,7 @@ using Harvest.Core.Domain;
 using Harvest.Core.Models;
 using Harvest.Core.Models.ProjectModels;
 using Harvest.Core.Services;
+using Harvest.Core.Utilities;
 using Harvest.Web.Models.MobileModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -332,9 +333,6 @@ namespace Harvest.Web.Controllers.Api
                 {
                     var rate = allRates.Single(a => a.Id == expense.RateId);
 
-                    var markupPrice = expense.Markup ? rate.Price * 1.2m : rate.Price;
-                    //TODO: Mobile needs to send the markup flag for Other rates.
-
                     expense.Approved = false; //Don't trust what we pass, or use a model instead?
                     expense.ApprovedById = null;
                     expense.ApprovedOn = null;
@@ -347,7 +345,7 @@ namespace Harvest.Web.Controllers.Api
                     expense.Account = rate.Account;
                     expense.Price = rate.Price;
                     expense.Type = rate.Type;
-                    expense.Total = Math.Round(markupPrice * expense.Quantity, 2, MidpointRounding.AwayFromZero); //was MidpointRounding.ToZero
+                    expense.Total = ExpenseCalculations.CalculateExpenseTotal(rate.Price, expense.Quantity, expense.Markup);
                     expense.IsPassthrough = rate.IsPassthrough;
                     if (autoApprove)
                     {

--- a/Harvest.Web/Controllers/Api/ProjectController.cs
+++ b/Harvest.Web/Controllers/Api/ProjectController.cs
@@ -147,7 +147,7 @@ namespace Harvest.Web.Controllers.Api
         [Route("/api/{team}/Project/Get/{projectId}/{shareId?}")]
         [Authorize(Policy = AccessCodes.InvoiceAccess)] //PI, Finance, Field Manager, Supervisor -- Don't really know a better name for this access (Maybe ProjectViewAccess?)        
         public async Task<ActionResult> Get(int projectId, Guid? shareId = null)
-        {            
+        {
             var user = await _userService.GetCurrentUser();
             var project = await _dbContext.Projects
                 .Include(a => a.Team)
@@ -170,7 +170,7 @@ namespace Harvest.Web.Controllers.Api
                 file.SasLink = _fileService.GetDownloadUrl(_storageSettings.ContainerName, file.Identifier).AbsoluteUri;
             }
 
-            if(shareId != null && project.ShareId != shareId)
+            if (shareId != null && project.ShareId != shareId)
             {
                 return BadRequest("share id invalid");
             }
@@ -257,13 +257,13 @@ namespace Harvest.Web.Controllers.Api
             {
                 return BadRequest("You are not the PI of this project or an editor of the project.");
             }
-            
+
             if (project.ProjectPermissions.Any(a => a.User?.Iam == postModel.User.Iam) || project.PrincipalInvestigator.Iam == postModel.User.Iam)
             {
                 return BadRequest("User already has a permission for this project.");
             }
 
-            if(postModel.Permission != Role.Codes.ProjectEditor && postModel.Permission != Role.Codes.ProjectViewer)
+            if (postModel.Permission != Role.Codes.ProjectEditor && postModel.Permission != Role.Codes.ProjectViewer)
             {
                 return BadRequest("Invalid permission type. Only Project Editor and Project Viewer are allowed.");
             }
@@ -273,7 +273,7 @@ namespace Harvest.Web.Controllers.Api
                 ProjectId = projectId,
                 Permission = postModel.Permission,
             };
-            
+
 
             //// create user if needed and assign to project
             var permissionUser = await _dbContext.Users.SingleOrDefaultAsync(x => x.Iam == postModel.User.Iam);
@@ -320,7 +320,7 @@ namespace Harvest.Web.Controllers.Api
             {
                 return NotFound("Permission not found.");
             }
-            if(permissionToRemove.User.Iam == user.Iam)
+            if (permissionToRemove.User.Iam == user.Iam)
             {
                 return BadRequest("You cannot remove your own permission from the project. Please contact the PI or another" +
                     " project editor to do this.");
@@ -329,10 +329,10 @@ namespace Harvest.Web.Controllers.Api
             await _historyService.AdhocHistory(projectId, "ProjectPermissionRemoved", $"Project Permission Removed:\n{permissionToRemove.User.Name}({permissionToRemove.User.Email}) with permission: {permissionToRemove.Permission.SplitCamelCase()}", project, true);
             _dbContext.ProjectPermissions.Remove(permissionToRemove);
 
-            
+
 
             await _dbContext.SaveChangesAsync();
-            
+
             return Ok();
         }
 
@@ -481,7 +481,7 @@ namespace Harvest.Web.Controllers.Api
                     {
                         return BadRequest("Negative Percentage Detected");
                     }
-                    newProject.Accounts.Add(account); 
+                    newProject.Accounts.Add(account);
                 }
 
                 if (percentage != 100.0m)
@@ -489,10 +489,17 @@ namespace Harvest.Web.Controllers.Api
                     return BadRequest("Percentage of accounts is not 100%");
                 }
 
-                var allRates = await _dbContext.Rates.Where(a => a.IsActive).ToListAsync();
+                var allRates = await _dbContext.Rates
+                    .Where(a => a.IsActive && a.TeamId == team.Id)
+                    .ToListAsync();
                 foreach (var expense in postModel.Expenses)
                 {
-                    var rate = allRates.Single(a => a.Id == expense.RateId);
+                    var rate = allRates.SingleOrDefault(a => a.Id == expense.RateId);
+                    if (rate == null)
+                    {
+                        return BadRequest($"Rate with ID of {expense.RateId} is not valid.");
+                    }
+
                     expense.CreatedBy = currentUser;
                     expense.CreatedOn = DateTime.UtcNow;
                     expense.Project = newProject;
@@ -574,12 +581,12 @@ namespace Harvest.Web.Controllers.Api
             {
                 return NotFound();
             }
-            if(existingProject.Status != Project.Statuses.Requested)
+            if (existingProject.Status != Project.Statuses.Requested)
             {
                 return BadRequest("Only projects in Requested status can be overridden.");
             }
 
-            if(project.Start.Date > project.End.Date)
+            if (project.Start.Date > project.End.Date)
             {
                 return BadRequest("Project start date cannot be after end date.");
             }
@@ -597,7 +604,7 @@ namespace Harvest.Web.Controllers.Api
 
                 var historyNotes = $"Project dates overridden from {oldStart.ToShortDateString()} - {oldEnd.ToShortDateString()} to {existingProject.Start.ToShortDateString()} - {existingProject.End.ToShortDateString()}";
                 await _historyService.AdhocHistory(project.Id, "ProjectDatesOverridden", historyNotes, existingProject, true);
-                
+
             }
             await _dbContext.SaveChangesAsync();
             return Ok(existingProject);

--- a/Harvest.Web/Controllers/Api/ProjectController.cs
+++ b/Harvest.Web/Controllers/Api/ProjectController.cs
@@ -522,6 +522,11 @@ namespace Harvest.Web.Controllers.Api
                 await _dbContext.Projects.AddAsync(newProject);
                 await _dbContext.SaveChangesAsync();
 
+                if (postModel.Quote == null)
+                {
+                    return BadRequest("Malformed payload: quote is required.");
+                }
+
                 ExpenseCalculations.NormalizeQuoteDetail(postModel.Quote);
                 newProject.QuoteTotal = (decimal)Math.Round(postModel.Quote.GrandTotal, 2);
 

--- a/Harvest.Web/Controllers/Api/ProjectController.cs
+++ b/Harvest.Web/Controllers/Api/ProjectController.cs
@@ -5,6 +5,7 @@ using Harvest.Core.Models;
 using Harvest.Core.Models.ProjectModels;
 using Harvest.Core.Models.Settings;
 using Harvest.Core.Services;
+using Harvest.Core.Utilities;
 using Harvest.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -491,12 +492,16 @@ namespace Harvest.Web.Controllers.Api
                 var allRates = await _dbContext.Rates.Where(a => a.IsActive).ToListAsync();
                 foreach (var expense in postModel.Expenses)
                 {
+                    var rate = allRates.Single(a => a.Id == expense.RateId);
                     expense.CreatedBy = currentUser;
                     expense.CreatedOn = DateTime.UtcNow;
                     expense.Project = newProject;
                     expense.InvoiceId = null;
-                    expense.Account = allRates.Single(a => a.Id == expense.RateId).Account;
-                    expense.IsPassthrough = allRates.Single(a => a.Id == expense.RateId).IsPassthrough;
+                    expense.Account = rate.Account;
+                    expense.Price = rate.Price;
+                    expense.Type = rate.Type;
+                    expense.Total = ExpenseCalculations.CalculateExpenseTotal(rate.Price, expense.Quantity, expense.Markup);
+                    expense.IsPassthrough = rate.IsPassthrough;
 
                     expense.Approved = true;
                     expense.ApprovedOn = DateTime.UtcNow;
@@ -509,6 +514,9 @@ namespace Harvest.Web.Controllers.Api
 
                 await _dbContext.Projects.AddAsync(newProject);
                 await _dbContext.SaveChangesAsync();
+
+                ExpenseCalculations.NormalizeQuoteDetail(postModel.Quote);
+                newProject.QuoteTotal = (decimal)Math.Round(postModel.Quote.GrandTotal, 2);
 
                 var quote = new Quote();
                 quote.InitiatedById = currentUser.Id;

--- a/Harvest.Web/Controllers/Api/QuoteController.cs
+++ b/Harvest.Web/Controllers/Api/QuoteController.cs
@@ -5,6 +5,7 @@ using Harvest.Core.Data;
 using Harvest.Core.Domain;
 using Harvest.Core.Models;
 using Harvest.Core.Services;
+using Harvest.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
@@ -107,6 +108,8 @@ namespace Harvest.Web.Controllers.Api
         [HttpPost]
         public async Task<ActionResult> Save(int projectId, bool submit, [FromBody] QuoteDetail quoteDetail)
         {
+            ExpenseCalculations.NormalizeQuoteDetail(quoteDetail);
+
             // only FM is allowed to submit a quote, anyone with access can save
             if (submit && !await _userService.HasAccess(AccessCodes.FieldManagerAccess, TeamSlug))
             {

--- a/Harvest.Web/Controllers/Api/QuoteController.cs
+++ b/Harvest.Web/Controllers/Api/QuoteController.cs
@@ -71,14 +71,14 @@ namespace Harvest.Web.Controllers.Api
             }
             else
             {
-                if(!hasAccess && project.PrincipalInvestigator.Id != user.Id && !project.ProjectPermissions.Any(a => a.User.Id == user.Id))
+                if (!hasAccess && project.PrincipalInvestigator.Id != user.Id && !project.ProjectPermissions.Any(a => a.User.Id == user.Id))
                 {
                     //return not authorized
                     return Unauthorized();
                 }
             }
 
-            
+
 
             var model = new QuoteModel
             {
@@ -91,11 +91,11 @@ namespace Harvest.Web.Controllers.Api
                 model.Quote.ApprovedOn = project.Quote?.ApprovedOn;
             }
 
-            if(project.QuoteId == null && project.OriginalProjectId != null)
+            if (project.QuoteId == null && project.OriginalProjectId != null)
             {
                 // Ok, we want to try to view the pending change request's quote.
                 var newQuote = await _dbContext.Quotes.SingleOrDefaultAsync(q => q.ProjectId == project.Id);
-                if(newQuote != null)
+                if (newQuote != null)
                 {
                     model.Quote = QuoteDetail.Deserialize(newQuote.Text);
                 }
@@ -108,13 +108,18 @@ namespace Harvest.Web.Controllers.Api
         [HttpPost]
         public async Task<ActionResult> Save(int projectId, bool submit, [FromBody] QuoteDetail quoteDetail)
         {
-            ExpenseCalculations.NormalizeQuoteDetail(quoteDetail);
+            if (quoteDetail == null)
+            {
+                return BadRequest("Malformed payload: quote is required.");
+            }
 
             // only FM is allowed to submit a quote, anyone with access can save
             if (submit && !await _userService.HasAccess(AccessCodes.FieldManagerAccess, TeamSlug))
             {
                 return Unauthorized();
             }
+
+            ExpenseCalculations.NormalizeQuoteDetail(quoteDetail);
 
 
             // Use existing quote if it exists, otherwise create new one
@@ -147,7 +152,7 @@ namespace Harvest.Web.Controllers.Api
             else
             {
                 await _historyService.QuoteSaved(projectId, quote);
-                if(!await _userService.HasAccess(AccessCodes.FieldManagerAccess, TeamSlug))
+                if (!await _userService.HasAccess(AccessCodes.FieldManagerAccess, TeamSlug))
                 {
                     await _emailService.SupervisorSavedQuote(project, quote);
                 }

--- a/Test/TestsServices/ExpenseCalculationsTests.cs
+++ b/Test/TestsServices/ExpenseCalculationsTests.cs
@@ -1,0 +1,79 @@
+using Harvest.Core.Models;
+using Harvest.Core.Utilities;
+using Shouldly;
+using Xunit;
+
+namespace Test.TestsServices
+{
+    [Trait("Category", "ServiceTest")]
+    public class ExpenseCalculationsTests
+    {
+        [Fact]
+        public void CalculateExpenseTotalAddsMarkupBelowCap()
+        {
+            var total = ExpenseCalculations.CalculateExpenseTotal(450m, 1m, true);
+
+            total.ShouldBe(540m);
+        }
+
+        [Fact]
+        public void CalculateExpenseTotalCapsMarkupPerExpense()
+        {
+            var total = ExpenseCalculations.CalculateExpenseTotal(900m, 10m, true);
+
+            total.ShouldBe(9200m);
+        }
+
+        [Fact]
+        public void NormalizeQuoteDetailRecalculatesWorkItemsAndRollups()
+        {
+            var quote = new QuoteDetail
+            {
+                ProjectName = "Test Project",
+                Acres = 0,
+                AcreageRate = 0,
+                Years = 1,
+                Activities = new[]
+                {
+                    new Activity
+                    {
+                        Id = 1,
+                        Name = "Activity 1",
+                        Adjustment = 10m,
+                        WorkItems = new[]
+                        {
+                            new WorkItem
+                            {
+                                Id = 1,
+                                ActivityId = 1,
+                                Type = "Other",
+                                Rate = 100,
+                                Quantity = 15,
+                                Markup = true,
+                            },
+                            new WorkItem
+                            {
+                                Id = 2,
+                                ActivityId = 1,
+                                Type = "Labor",
+                                Rate = 50,
+                                Quantity = 2,
+                                Markup = false,
+                            },
+                        },
+                    },
+                },
+            };
+
+            ExpenseCalculations.NormalizeQuoteDetail(quote);
+
+            quote.Activities[0].WorkItems[0].Total.ShouldBe(1850d);
+            quote.Activities[0].WorkItems[1].Total.ShouldBe(110d);
+            quote.Activities[0].Total.ShouldBe(1960d);
+            quote.OtherTotal.ShouldBe(1850d);
+            quote.LaborTotal.ShouldBe(110d);
+            quote.ActivitiesTotal.ShouldBe(1960d);
+            quote.GrandTotal.ShouldBe(1960d);
+        }
+    }
+}


### PR DESCRIPTION
Introduces a new markup rule: 20% on the base total of an expense, capped at $1,000 of the base total (resulting in a maximum markup of $200 per expense item).

All expense and quote related calculations are centralized into a new `ExpenseCalculations` utility, ensuring consistent application of the new markup rule and other total calculations across the backend API and frontend UI. This includes a `NormalizeQuoteDetail` function to accurately recalculate all quote component totals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server now validates rates per project/team and always recalculates expense totals for consistent, authoritative totals.
  * Markup calculation refined: 20% applied only to the first $1,000 of an expense (max $200).

* **New Features**
  * Quote normalization and centralized expense-calculation utilities added and used server-side to recompute work-item, activity, category, and grand totals.

* **Documentation**
  * Tooltip clarified to describe the revised markup rule.

* **Tests**
  * Added tests covering expense calculations and quote normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->